### PR TITLE
ci: set HELPCHAIN_TEST_DEBUG=0 (disable tracing in CI)

### DIFF
--- a/backend/.github/workflows/ci.yml
+++ b/backend/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      HELPCHAIN_TEST_DEBUG: '0'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/backend/.github/workflows/python-tests.yml
+++ b/backend/.github/workflows/python-tests.yml
@@ -16,6 +16,8 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      HELPCHAIN_TEST_DEBUG: '0'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Set up Python


### PR DESCRIPTION
Set HELPCHAIN_TEST_DEBUG=0 in backend CI workflows to ensure CI runs do not enable tracing/tracemalloc.

Files changed:
- backend/.github/workflows/ci.yml
- backend/.github/workflows/python-tests.yml

This is a non-invasive change that only exports an environment variable to make CI deterministic (no tracing).