### PR TITLE
ci: add python-tests workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,41 @@
+name: Python CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      HELPCHAIN_TEST_DEBUG: "0"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f backend/requirements.txt ]; then pip install -r backend/requirements.txt; fi
+          pip install pre-commit
+      - name: Run pre-commit
+        run: |
+          pre-commit run --all-files || true
+      - name: Run tests
+        run: |
+          if [ -f backend/pytest.ini ] || [ -d backend/tests ]; then
+            pytest -q
+          else
+            echo "No tests found"
+          fi


### PR DESCRIPTION
Add root-level python-tests workflow so PRs run pytest and produce logs (needed to validate DB schema debug prints).