### PR TITLE
ci: run DB migrations before tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -29,6 +29,10 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f backend/requirements.txt ]; then pip install -r backend/requirements.txt; fi
           pip install pre-commit
+      - name: Run database migrations
+        # Ensure the test database schema is created before running pytest
+        run: |
+          python run_migrations.py || true
       - name: Run pre-commit
         run: |
           pre-commit run --all-files || true


### PR DESCRIPTION
Run project migrations prior to running pytest so test DB schema is created on CI.

This adds a step which executes `python run_migrations.py` before `pytest`.

If migrations fail, tests will still run (the step is tolerant) but the logs will show the migration error for follow-up.