### PR TITLE
Adds a structured documentation index for HelpChain and introduces core product, architecture, and local development documentation.

### DIFF
--- a/docs/00-overview/product-overview.md
+++ b/docs/00-overview/product-overview.md
@@ -1,0 +1,31 @@
+﻿# Product Overview
+
+## What HelpChain is
+
+HelpChain is a coordination platform for organizations that need to receive, qualify, assign, monitor and follow social or operational requests across teams.
+
+It is not designed to replace every existing tool. It adds a structured coordination layer above fragmented channels such as email, spreadsheets, phone calls and informal messaging.
+
+## Who it is for
+
+HelpChain is designed for:
+
+- municipalities
+- CCAS and local social services
+- associations
+- professional coordination teams
+- field operators
+- institutional pilot programs
+
+## Core value
+
+HelpChain helps teams move from scattered requests to structured operational follow-up:
+
+- centralized request intake
+- visible ownership
+- status and priority tracking
+- case follow-up
+- operational dashboards
+- audit and traceability
+- role-based access
+- risk and SLA indicators

--- a/docs/02-architecture/system-architecture.md
+++ b/docs/02-architecture/system-architecture.md
@@ -1,0 +1,40 @@
+﻿# System Architecture
+
+## Overview
+
+HelpChain is a Flask-based web application using server-rendered templates, modular backend routes and a relational database.
+
+The platform is structured around:
+
+- public pages
+- admin workspace
+- operator workspace
+- request management
+- case management
+- professional lead management
+- notifications
+- audit and activity logs
+- KPI and risk surfaces
+
+## Core stack
+
+- Python / Flask
+- SQLAlchemy
+- Alembic migrations
+- Jinja templates
+- PostgreSQL in production
+- SQLite for local development
+- Render deployment
+- Neon Postgres database
+- GitHub Actions
+- AWS S3 backups
+
+## Main operational concepts
+
+- Structure: tenant or organization using the platform
+- Service: internal service/team inside a structure
+- Request: incoming need or operational demand
+- Case: structured follow-up object linked to a request
+- Admin user: privileged user managing operations
+- Operator: user focused on daily operational queue handling
+- Intervenant: person or actor assigned to intervention/follow-up

--- a/docs/07-devops/local-development-runbook.md
+++ b/docs/07-devops/local-development-runbook.md
@@ -1,0 +1,6 @@
+﻿# Local Development Runbook
+
+## Start local environment
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\help.ps1

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,75 +1,84 @@
-# HelpChain Documentation
+﻿# HelpChain Documentation
 
-## What HelpChain Is
+HelpChain is a digital coordination infrastructure for structured social, municipal, associative and professional support workflows.
 
-HelpChain is a France-first institutional coordination platform for managing requests, assignments, operational follow-up, and controlled access across structures. It is designed for public-interest and institutional environments that require traceability, role-based access, and operational clarity.
+This documentation is organized as an operational knowledge base for product, architecture, security, admin operations, DevOps and release work.
 
-## Documentation Principles
+## Documentation map
 
-- Documentation is organized by domain so operational, product, architectural, and governance material remain easy to navigate.
-- English is the primary documentation language for the active documentation tree.
-- Archived material is preserved for historical reference only and must not be treated as the current source of truth.
-- Canonical governance documents for the Request domain remain authoritative and should be read before changing workflow behavior.
+### 00 — Overview
 
-## Documentation Map
+- [Product overview](00-overview/product-overview.md)
+- [Documentation status](00-overview/documentation-status.md)
+- [HelpChain overview FR](00-overview/HelpChain_Overview_FR.md)
+- [HelpChain overview EN](00-overview/HelpChain_Overview_EN.md)
 
-- `00-overview/` Institutional and executive-level platform overviews.
-- `01-product/` Product-facing documentation and positioning material when maintained.
-- `02-architecture/` Canonical structural model, migration plans, and target-state architecture.
-- `03-request-domain/` Governance baselines for the Request lifecycle, permissions, API contract, and reporting rules.
-- `04-admin-operations/` Practical guidance for the admin workspace and operational workflows.
-- `05-api/` API-specific documentation that does not belong to request governance or security.
-- `06-security/` Access control, data protection, privacy boundaries, and secret-handling guidance.
-- `07-devops/` Deployment, local development, CI/CD, and runtime integration notes.
-- `08-runbooks/` Operational procedures for health checks, restores, and recurring jobs.
-- `09-quality/` Quality standards, UX guardrails, accessibility checks, and regression baselines.
-- `archive/` Historical, temporary, superseded, or investigative material preserved for context.
+### 02 — Architecture
 
-## Start Here If You Are...
+- [System architecture](02-architecture/system-architecture.md)
+- [Data model](02-architecture/data-model.md)
+- [Intervenant migration plan](02-architecture/intervenant-migration-plan.md)
+- [Intervenant cutover plan](02-architecture/intervenant-cutover-plan.md)
 
-### Developer
+### 03 — Request domain
 
-Start with:
+- [Request status model](03-request-domain/request-status-model.md)
+- [Request permission model](03-request-domain/request-permission-model.md)
+- [Request API contract](03-request-domain/request-api-contract.md)
+- [Request lifecycle engine](03-request-domain/request-lifecycle-engine.md)
+- [Request admin action audit](03-request-domain/request-admin-action-audit.md)
+- [Request query and reporting rules](03-request-domain/request-query-and-reporting-rules.md)
 
-- `07-devops/local-development.md`
-- `02-architecture/data-model.md`
-- `03-request-domain/request-api-contract.md`
-- `03-request-domain/request-lifecycle-engine.md`
+### 04 — Admin operations
 
-### Operator / Admin
+- [Admin panel manual](04-admin-operations/admin-panel-manual.md)
+- [Admin v3 operational upgrade](04-admin-operations/admin-v3-operational-upgrade.md)
 
-Start with:
+### 06 — Security
 
-- `04-admin-operations/admin-panel-manual.md`
-- `08-runbooks/health-and-sanity.md`
-- `08-runbooks/mini-runbook.md`
-- `08-runbooks/restore-runbook.md`
+- [Access and endpoints](06-security/access-and-endpoints.md)
+- [Production data safety](06-security/production-data-safety.md)
+- [Secret safety](06-security/secret-safety.md)
+- [Volunteers nearby privacy](06-security/volunteers-nearby-privacy.md)
 
-### Product / Stakeholder Reader
+### 07 — DevOps
 
-Start with:
+- [Local development runbook](07-devops/local-development-runbook.md)
+- [Local development](07-devops/local-development.md)
+- [Deployment](07-devops/deployment.md)
+- [CI/CD](07-devops/ci-cd.md)
+- [Preview health](07-devops/preview-health.md)
 
-- `00-overview/HelpChain_Overview_EN.md`
-- `02-architecture/data-model.md`
-- `04-admin-operations/admin-v3-operational-upgrade.md`
+### 08 — Runbooks
 
-## Canonical Documents
+- [Health and sanity](08-runbooks/health-and-sanity.md)
+- [Restore runbook](08-runbooks/restore-runbook.md)
+- [Notification jobs runbook](08-runbooks/notification-jobs-runbook.md)
+- [Stability lockdown checklist](08-runbooks/stability-lockdown-checklist.md)
 
-The following documents define the active source of truth for request governance and runtime operations:
+### 09 — Quality
 
-- `03-request-domain/request-status-model.md`
-- `03-request-domain/request-admin-action-audit.md`
-- `03-request-domain/request-permission-model.md`
-- `03-request-domain/request-api-contract.md`
-- `03-request-domain/request-lifecycle-engine.md`
-- `03-request-domain/request-query-and-reporting-rules.md`
-- `02-architecture/data-model.md`
-- `06-security/access-and-endpoints.md`
-- `07-devops/deployment.md`
-- `06-security/production-data-safety.md`
-- `08-runbooks/restore-runbook.md`
-- `08-runbooks/health-and-sanity.md`
+- [UX rules](09-quality/ux-rules.md)
+- [Frontend security](09-quality/frontend-security.md)
+- [Accessibility checklist](09-quality/a11y-checklist.md)
+- [Visual regression baseline](09-quality/visual-regression-baseline.md)
 
-## Archive
+## Strategic documents
 
-Archived documents are retained for institutional memory, incident review, migration history, or past audits. They may contain outdated assumptions, machine-specific details, or time-bound conclusions and must not be used as active operational guidance.
+- [Founder operating playbook](founder-operating-playbook.md)
+- [First 10 paying clients plan](first-10-paying-clients-plan.md)
+- [First 2000 EUR MRR war plan](first-2000-eur-mrr-war-plan.md)
+- [Founder daily execution system](founder-daily-execution-system.md)
+- [Founder war room dashboard](founder-war-room-dashboard.md)
+
+## Operating principle
+
+Documentation must stay practical, readable and close to the product.
+
+Every major feature should eventually have:
+
+- product intent
+- operational flow
+- technical implementation notes
+- security and access implications
+- runbook or troubleshooting notes when relevant


### PR DESCRIPTION
## Summary
- Short description of the change

## Motivation
- Why is this change needed?

## Changes
- Key points:
  - ...

## Preview Health (Vercel)
- Canonical health endpoint for previews: `/health`.
- `/api/_health` may be 404 if Project-level Routes in Vercel override repo `vercel.json`.
- Our smoke script treats `/api/_health = 404` as a soft warning when `/health = 200`.
- To force `/api/_health = 200`, add UI route (Project Settings → Routing): `^/api/_health$ → api/_health.js` before other rules.

## Checklist
- [ ] Tests pass locally (`pytest`)
- [ ] Updated docs/README where applicable
- [ ] Smoke passed on preview deployment(s)
- [ ] Security considerations reviewed
