### PR TITLE
Separate canonical and compatibility test boundaries

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,10 @@
 addopts = -v -p no:flask --basetemp=.pytest_tmp
 markers =
     smoke_admin: lightweight admin smoke checks (no-500 contracts)
+    spine: canonical operational spine tests for Request/Case/Assignment/SLA/ops/reporting flows
+    compat_social_request: compatibility tests for legacy SocialRequest and /requests/* flows
+    shared_platform: shared platform/auth/permission/reporting infrastructure tests
+    mixed_transition: mixed transition tests covering both canonical and compatibility contracts
 
 # Discovery
 testpaths =

--- a/tests/test_admin_intervenant_detail_routes.py
+++ b/tests/test_admin_intervenant_detail_routes.py
@@ -1,6 +1,9 @@
 from datetime import timedelta
 
+import pytest
 from werkzeug.security import generate_password_hash
+
+pytestmark = pytest.mark.spine
 
 
 def _login_admin(client, app, admin_user):

--- a/tests/test_admin_operator_visibility.py
+++ b/tests/test_admin_operator_visibility.py
@@ -3,6 +3,9 @@ import re
 from urllib.parse import parse_qs, urlparse
 
 from bs4 import BeautifulSoup
+import pytest
+
+pytestmark = pytest.mark.spine
 
 
 def _satisfy_privileged_mfa(client, session, admin_user):

--- a/tests/test_admin_permissions_extra.py
+++ b/tests/test_admin_permissions_extra.py
@@ -4,6 +4,8 @@ import pytest
 
 from backend.models import AdminUser, utc_now
 
+pytestmark = pytest.mark.mixed_transition
+
 
 def _admin_id_from_client(client) -> int:
     with client.session_transaction() as sess:

--- a/tests/test_admin_rbac_security_pass.py
+++ b/tests/test_admin_rbac_security_pass.py
@@ -1,6 +1,10 @@
 from uuid import uuid4
 
+import pytest
+
 from backend.models import AdminUser, Request, RequestActivity, Structure, User
+
+pytestmark = pytest.mark.spine
 
 
 def _login_admin(client, admin_user):

--- a/tests/test_admin_request_new_smoke.py
+++ b/tests/test_admin_request_new_smoke.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+import pytest
+
 from backend.models import Request
+
+pytestmark = pytest.mark.spine
 
 
 def test_admin_request_new_get_smoke(authenticated_admin_client):

--- a/tests/test_admin_requests_bulk_actions_backend.py
+++ b/tests/test_admin_requests_bulk_actions_backend.py
@@ -4,6 +4,8 @@ import pytest
 
 from backend.models import AdminUser, Request, Structure, User
 
+pytestmark = pytest.mark.spine
+
 
 def _admin_id_from_client(client) -> int:
     with client.session_transaction() as sess:

--- a/tests/test_admin_requests_bulk_actions_ui.py
+++ b/tests/test_admin_requests_bulk_actions_ui.py
@@ -2,6 +2,8 @@ import re
 
 import pytest
 
+pytestmark = pytest.mark.spine
+
 
 @pytest.fixture
 def admin_login(authenticated_admin_client):

--- a/tests/test_admin_requests_bulk_guard.py
+++ b/tests/test_admin_requests_bulk_guard.py
@@ -1,5 +1,9 @@
 import re
 
+import pytest
+
+pytestmark = pytest.mark.spine
+
 
 def _csrf(html: str) -> str:
     m = re.search(r'name="csrf_token"\s+value="([^"]+)"', html)

--- a/tests/test_admin_requests_bulk_nudge_backend.py
+++ b/tests/test_admin_requests_bulk_nudge_backend.py
@@ -4,6 +4,8 @@ import pytest
 
 from backend.models import AdminUser, Notification, Request, RequestActivity, Structure, User, Volunteer
 
+pytestmark = pytest.mark.spine
+
 
 def _admin_id_from_client(client) -> int:
     with client.session_transaction() as sess:

--- a/tests/test_admin_requests_inactive_queue.py
+++ b/tests/test_admin_requests_inactive_queue.py
@@ -2,6 +2,10 @@ from datetime import UTC, datetime, timedelta
 
 from bs4 import BeautifulSoup
 
+import pytest
+
+pytestmark = pytest.mark.spine
+
 
 def _request_titles(html: str) -> set[str]:
     soup = BeautifulSoup(html, "html.parser")

--- a/tests/test_admin_requests_never_500.py
+++ b/tests/test_admin_requests_never_500.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytestmark = pytest.mark.spine
+
 
 @pytest.fixture
 def admin_login(authenticated_admin_client):

--- a/tests/test_admin_requests_table_headers.py
+++ b/tests/test_admin_requests_table_headers.py
@@ -1,3 +1,8 @@
+import pytest
+
+pytestmark = pytest.mark.spine
+
+
 def test_requests_table_headers(authenticated_admin_client):
     r = authenticated_admin_client.get("/admin/requests")
     assert r.status_code == 200

--- a/tests/test_admin_sla_drilldown_smoke.py
+++ b/tests/test_admin_sla_drilldown_smoke.py
@@ -2,7 +2,11 @@ from datetime import UTC, datetime, timedelta
 import re
 from uuid import uuid4
 
+import pytest
+
 from backend.models import AdminUser, Request, Structure, User
+
+pytestmark = pytest.mark.spine
 
 
 def _admin_id_from_client(client) -> int:

--- a/tests/test_admin_structures_onboarding.py
+++ b/tests/test_admin_structures_onboarding.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytestmark = pytest.mark.shared_platform
+
 
 def _login_admin(client, admin_user):
     with client.session_transaction() as s:

--- a/tests/test_architecture_social_request_boundaries.py
+++ b/tests/test_architecture_social_request_boundaries.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.spine
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+FORBIDDEN_SYMBOLS = {"SocialRequest", "SocialRequestEvent"}
+FORBIDDEN_MODULE_FRAGMENTS = ("social_request",)
+
+PROTECTED_MODULES = {
+    "reporting": [
+        "backend/helpchain_backend/src/services/reporting/operations_report.py",
+        "backend/helpchain_backend/src/services/weekly_operations_report.py",
+        "backend/helpchain_backend/src/services/daily_health_report.py",
+    ],
+    "sla": [
+        "backend/helpchain_backend/src/services/request_sla.py",
+        "backend/helpchain_backend/src/services/sla_alerts.py",
+    ],
+    "assignment": [
+        "backend/helpchain_backend/src/routes/admin.py",
+        "backend/helpchain_backend/src/routes/admin_requests.py",
+        "backend/helpchain_backend/src/routes/admin_cases.py",
+    ],
+}
+
+
+def _parse_module(relative_path: str) -> ast.AST:
+    path = REPO_ROOT / relative_path
+    source = path.read_text(encoding="utf-8-sig")
+    return ast.parse(source, filename=str(path))
+
+
+def _forbidden_references(relative_path: str) -> list[str]:
+    tree = _parse_module(relative_path)
+    hits: set[str] = set()
+
+    class ForbiddenReferenceVisitor(ast.NodeVisitor):
+        def visit_Import(self, node: ast.Import) -> None:
+            for alias in node.names:
+                if any(fragment in alias.name.lower() for fragment in FORBIDDEN_MODULE_FRAGMENTS):
+                    hits.add(f"import {alias.name}")
+            self.generic_visit(node)
+
+        def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+            module_name = (node.module or "").lower()
+            if any(fragment in module_name for fragment in FORBIDDEN_MODULE_FRAGMENTS):
+                hits.add(f"from {node.module} import ...")
+            for alias in node.names:
+                if alias.name in FORBIDDEN_SYMBOLS:
+                    hits.add(f"from {node.module} import {alias.name}")
+                if any(fragment in alias.name.lower() for fragment in FORBIDDEN_MODULE_FRAGMENTS):
+                    hits.add(f"from {node.module} import {alias.name}")
+            self.generic_visit(node)
+
+        def visit_Name(self, node: ast.Name) -> None:
+            if node.id in FORBIDDEN_SYMBOLS:
+                hits.add(f"name {node.id}")
+            self.generic_visit(node)
+
+        def visit_Attribute(self, node: ast.Attribute) -> None:
+            if node.attr in FORBIDDEN_SYMBOLS:
+                hits.add(f"attribute {node.attr}")
+            self.generic_visit(node)
+
+    ForbiddenReferenceVisitor().visit(tree)
+    return sorted(hits)
+
+
+@pytest.mark.parametrize("relative_path", PROTECTED_MODULES["reporting"])
+def test_reporting_modules_do_not_depend_on_social_request(relative_path: str):
+    assert _forbidden_references(relative_path) == [], (
+        "Canonical reporting modules must stay on the Request/Case operational spine; "
+        f"found SocialRequest dependency in {relative_path}: {_forbidden_references(relative_path)}"
+    )
+
+
+@pytest.mark.parametrize("relative_path", PROTECTED_MODULES["sla"])
+def test_sla_modules_do_not_depend_on_social_request(relative_path: str):
+    assert _forbidden_references(relative_path) == [], (
+        "Canonical SLA modules must stay on the Request/Case operational spine; "
+        f"found SocialRequest dependency in {relative_path}: {_forbidden_references(relative_path)}"
+    )
+
+
+@pytest.mark.parametrize("relative_path", PROTECTED_MODULES["assignment"])
+def test_assignment_modules_do_not_depend_on_social_request(relative_path: str):
+    assert _forbidden_references(relative_path) == [], (
+        "Canonical assignment orchestration must stay on the Request/Case operational spine; "
+        f"found SocialRequest dependency in {relative_path}: {_forbidden_references(relative_path)}"
+    )

--- a/tests/test_auth_access_invariants.py
+++ b/tests/test_auth_access_invariants.py
@@ -4,11 +4,14 @@ from datetime import timedelta
 from uuid import uuid4
 
 import pyotp
+import pytest
 
 from backend.models import AdminUser, Request, Structure, User, utc_now
 
 
 TEST_ADMIN_PASSWORD = "TestPassword1"
+
+pytestmark = pytest.mark.shared_platform
 
 
 def _default_structure(session) -> Structure:

--- a/tests/test_case_summary_service_smoke.py
+++ b/tests/test_case_summary_service_smoke.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from backend.helpchain_backend.src.services.case_summary import build_case_summary
+
+pytestmark = pytest.mark.spine
 
 
 def test_case_summary_critical_no_owner():

--- a/tests/test_case_summary_smoke.py
+++ b/tests/test_case_summary_smoke.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from types import SimpleNamespace
 
+import pytest
+
 from backend.helpchain_backend.src.services.case_summary import build_case_summary
 from backend.models import Request, Structure, User
+
+pytestmark = pytest.mark.spine
 
 
 def _make_user(session, suffix: str) -> User:

--- a/tests/test_cases_workflow_stability.py
+++ b/tests/test_cases_workflow_stability.py
@@ -1,5 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
+import pytest
+
+pytestmark = pytest.mark.spine
+
 
 def _login_admin(client, admin_user):
     with client.session_transaction() as sess:

--- a/tests/test_daily_health_report.py
+++ b/tests/test_daily_health_report.py
@@ -8,6 +8,8 @@ import pytest
 from backend.models import AdminUser, db
 from backend.helpchain_backend.src.services import daily_health_report
 
+pytestmark = pytest.mark.shared_platform
+
 
 @pytest.fixture
 def health_report_app(monkeypatch):

--- a/tests/test_endpoint_security.py
+++ b/tests/test_endpoint_security.py
@@ -1,6 +1,8 @@
 import pytest
 from werkzeug.security import generate_password_hash
 
+pytestmark = pytest.mark.shared_platform
+
 
 def _ensure_structure(session, structure_id: int, name: str, slug: str):
     from backend.models import Structure

--- a/tests/test_full_request_flow_html.py
+++ b/tests/test_full_request_flow_html.py
@@ -4,6 +4,8 @@ import pytest
 
 from backend.models import AdminAuditEvent, AdminUser, SocialRequest, SocialRequestEvent, User
 
+pytestmark = pytest.mark.mixed_transition
+
 
 def _admin_id_from_client(client) -> int:
     with client.session_transaction() as sess:

--- a/tests/test_operations_report.py
+++ b/tests/test_operations_report.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 
+import pytest
+
 from backend.extensions import db
 from backend.models import Request, Structure
 from backend.helpchain_backend.src.services.reporting.operations_report import (
     build_operational_report,
 )
+
+pytestmark = pytest.mark.spine
 
 
 def _make_structure(name: str = "Test Structure") -> Structure:

--- a/tests/test_request_details_workspace.py
+++ b/tests/test_request_details_workspace.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from bs4 import BeautifulSoup
+import pytest
 
 from backend.models import Request, Structure, User
+
+pytestmark = pytest.mark.mixed_transition
 
 
 def _make_user(session, suffix: str) -> User:

--- a/tests/test_request_flow_smoke.py
+++ b/tests/test_request_flow_smoke.py
@@ -7,6 +7,8 @@ import os
 from backend.models import AdminUser, Request, Structure, db, utc_now
 import pytest
 
+pytestmark = pytest.mark.spine
+
 
 def _submit_public_request(client, unique_suffix: str) -> str:
     title = f"Smoke request {unique_suffix}"

--- a/tests/test_request_sla_engine.py
+++ b/tests/test_request_sla_engine.py
@@ -9,6 +9,8 @@ import pytest
 from backend.models import AdminUser, Request, RequestActivity, Structure, User, db, utc_now
 from backend.helpchain_backend.src.services import request_sla
 
+pytestmark = pytest.mark.spine
+
 
 @pytest.fixture
 def sla_engine_app(monkeypatch):

--- a/tests/test_requests_edge_cases.py
+++ b/tests/test_requests_edge_cases.py
@@ -4,6 +4,8 @@ import pytest
 
 from backend.models import AdminUser, Request, SocialRequest
 
+pytestmark = pytest.mark.mixed_transition
+
 
 def _admin_id_from_client(client) -> int:
     with client.session_transaction() as sess:

--- a/tests/test_risk_engine.py
+++ b/tests/test_risk_engine.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from backend.extensions import db
 from backend.helpchain_backend.src.models import (
     AdminUser,
@@ -10,6 +12,8 @@ from backend.helpchain_backend.src.models import (
     User,
 )
 from backend.models import Assignment, Intervenant
+
+pytestmark = pytest.mark.spine
 
 
 def _login_admin_session(client, admin_id: int):

--- a/tests/test_risk_engine_smoke.py
+++ b/tests/test_risk_engine_smoke.py
@@ -4,9 +4,13 @@ import json
 from datetime import UTC, datetime
 from uuid import uuid4
 
+import pytest
+
 from sqlalchemy import inspect, text
 
 from backend.models import Request, Structure, User
+
+pytestmark = pytest.mark.mixed_transition
 
 
 def _make_user(session) -> User:

--- a/tests/test_sla_alerts.py
+++ b/tests/test_sla_alerts.py
@@ -3,6 +3,9 @@
 from backend.extensions import db
 from backend.models import Request
 from backend.helpchain_backend.src.services.sla_alerts import build_sla_alerts
+import pytest
+
+pytestmark = pytest.mark.spine
 
 
 def test_sla_alerts_detect_unassigned_and_stale_requests(app, db_schema):

--- a/tests/test_social_requests_smoke.py
+++ b/tests/test_social_requests_smoke.py
@@ -1,3 +1,8 @@
+import pytest
+
+pytestmark = pytest.mark.compat_social_request
+
+
 def test_social_requests_pages(client, authenticated_admin_client, init_test_data, db_session):
     from backend.models import SocialRequest, SocialRequestEvent, User
 

--- a/tests/test_weekly_operations_report.py
+++ b/tests/test_weekly_operations_report.py
@@ -1,10 +1,14 @@
 from datetime import UTC, datetime, timedelta
 
+import pytest
+
 from backend.extensions import db
 from backend.models import AdminUser, Request, Structure
 from backend.helpchain_backend.src.services.weekly_operations_report import (
     enqueue_weekly_operations_report,
 )
+
+pytestmark = pytest.mark.spine
 
 
 def test_enqueue_weekly_operations_report_creates_notification_job(app, db_schema):


### PR DESCRIPTION
## Summary
- registers pytest markers for canonical spine, compatibility, shared platform, and mixed transition tests
- marks clearly classified canonical and SocialRequest compatibility test groups
- adds AST-based architecture guards preventing SocialRequest usage in canonical reporting, SLA, and assignment modules

## Validation
- pre-commit hook passed
- tests/test_auth_access_invariants.py passed
- targeted Stage 3 validation passed locally
- encoding guard passed
