### PR TITLE
Add canonical request status read normalization

### DIFF
--- a/backend/admin/ops_api.py
+++ b/backend/admin/ops_api.py
@@ -5,6 +5,9 @@ from flask_login import current_user
 from sqlalchemy import func
 
 from backend.extensions import db
+from backend.helpchain_backend.src.statuses import (
+    request_status_read_values,
+)
 from backend.models import Request
 
 ops_api = Blueprint("ops_api", __name__)
@@ -30,7 +33,11 @@ def ops_metrics():
 
     active = (
         db.session.query(func.count(Request.id))
-        .filter(Request.status == "active")
+        .filter(
+            func.lower(func.coalesce(Request.status, "")).in_(
+                request_status_read_values("open", active_as="open")
+            )
+        )
         .scalar()
         or 0
     )
@@ -54,7 +61,11 @@ def ops_metrics():
     if resolved_col is not None:
         resolved_today = (
             db.session.query(func.count(Request.id))
-            .filter(Request.status.in_(("resolved", "completed")))
+            .filter(
+                func.lower(func.coalesce(Request.status, "")).in_(
+                    request_status_read_values("done")
+                )
+            )
             .filter(func.date(resolved_col) == now.date())
             .scalar()
             or 0

--- a/backend/helpchain_backend/src/routes/admin_requests.py
+++ b/backend/helpchain_backend/src/routes/admin_requests.py
@@ -55,7 +55,12 @@ from ..services.request_sla import (
     build_request_inactivity_components,
     request_dashboard_actionable_filter,
 )
-from ..statuses import REQUEST_STATUS_ALLOWED, normalize_request_status
+from ..statuses import (
+    REQUEST_STATUS_ALLOWED,
+    normalize_request_status,
+    request_status_read_values,
+    request_terminal_status_read_values,
+)
 from .admin import (
     ASSIGN_SLA_HOURS,
     CASE_PRIORITY_RANK,
@@ -1134,19 +1139,23 @@ def _request_status_bucket_filter(tab: str):
     status_value = _request_status_value()
     terminal_status = _request_terminal_status_filter()
     if tab == "NEW":
-        return status_value.in_(["new", "pending"])
+        return status_value.in_(["new", *request_status_read_values("open", active_as="open")])
     if tab == "IN_PROGRESS":
-        return status_value.in_(["approved", "in_progress", "in progress"])
-    if tab == "COMPLETED":
         return status_value.in_(
             [
-                "done",
-                "completed",
+                *request_status_read_values("in_progress", active_as="in_progress"),
+                "in progress",
+            ]
+        )
+    if tab == "COMPLETED":
+        return status_value.in_(request_status_read_values("done"))
+    if tab == "CLOSED":
+        return status_value.in_(
+            [
+                *request_status_read_values("cancelled"),
                 "closed",
             ]
         )
-    if tab == "CLOSED":
-        return status_value.in_(["rejected", "cancelled", "canceled", "closed"])
     if tab == "URGENT":
         return and_(
             func.lower(func.coalesce(Request.priority, "low")).in_(
@@ -1171,9 +1180,7 @@ def _request_status_value():
 
 
 def _request_terminal_status_filter():
-    return _request_status_value().in_(
-        ["done", "completed", "rejected", "cancelled", "canceled", "closed"]
-    )
+    return _request_status_value().in_(request_terminal_status_read_values())
 
 
 def _request_non_terminal_status_filter():
@@ -1183,7 +1190,12 @@ def _request_non_terminal_status_filter():
 def _request_actionable_filter():
     status_value = _request_status_value()
     terminal_status = _request_terminal_status_filter()
-    in_progress = status_value.in_(["approved", "in_progress", "in progress"])
+    in_progress = status_value.in_(
+        [
+            *request_status_read_values("in_progress", active_as="in_progress"),
+            "in progress",
+        ]
+    )
     unassigned_open = and_(Request.assigned_volunteer_id.is_(None), ~terminal_status)
 
     has_can_help = false()

--- a/backend/helpchain_backend/src/routes/admin_requests.py
+++ b/backend/helpchain_backend/src/routes/admin_requests.py
@@ -1139,7 +1139,12 @@ def _request_status_bucket_filter(tab: str):
     status_value = _request_status_value()
     terminal_status = _request_terminal_status_filter()
     if tab == "NEW":
-        return status_value.in_(["new", *request_status_read_values("open", active_as="open")])
+        new_queue_statuses = tuple(
+            value
+            for value in request_status_read_values("open", active_as="open")
+            if value not in {"open", "active"}
+        )
+        return status_value.in_(["new", *new_queue_statuses])
     if tab == "IN_PROGRESS":
         return status_value.in_(
             [

--- a/backend/helpchain_backend/src/services/reporting/operations_report.py
+++ b/backend/helpchain_backend/src/services/reporting/operations_report.py
@@ -7,27 +7,18 @@ from datetime import UTC, datetime, timedelta
 from sqlalchemy import and_, func, or_
 
 from backend.extensions import db
+from backend.helpchain_backend.src.statuses import (
+    canonical_request_status,
+    request_status_read_values,
+    request_terminal_status_read_values,
+)
 from backend.models import Intervenant, Request, Structure
 from backend.helpchain_backend.src.services.sla_alerts import build_sla_alerts
 
 
-CLOSED_STATUSES = {
-    "done",
-    "cancelled",
-    "rejected",
-    "canceled",
-    "closed",
-    "completed",
-    "resolved",
-    "archived",
-}
+CLOSED_STATUSES = set(request_terminal_status_read_values()) | {"archived"}
 
-RESOLVED_STATUSES = {
-    "done",
-    "closed",
-    "completed",
-    "resolved",
-}
+RESOLVED_STATUSES = set(request_status_read_values("done"))
 
 PRIORITY_SEVERITY_RANK = {
     "stable": 1,
@@ -180,6 +171,31 @@ def _rows_by_label(rows, label_name: str, count_name: str = "count") -> list[dic
     ]
 
 
+def _canonical_status_rows(rows) -> list[dict]:
+    counts: OrderedDict[str, int] = OrderedDict()
+    unknown_counts: OrderedDict[str, int] = OrderedDict()
+
+    for raw_status, count in rows:
+        canonical = canonical_request_status(
+            raw_status,
+            active_as="open",
+            fallback=str(raw_status or "").strip().lower() or "unknown",
+        )
+        target = counts if canonical in {"open", "in_progress", "done", "cancelled"} else unknown_counts
+        target[canonical] = target.get(canonical, 0) + int(count or 0)
+
+    result = [
+        {"status": status, "count": counts[status]}
+        for status in ("open", "in_progress", "done", "cancelled")
+        if counts.get(status)
+    ]
+    result.extend(
+        {"status": status, "count": count}
+        for status, count in unknown_counts.items()
+    )
+    return result
+
+
 def _trend_semantic(direction: str, positive_when: str = "up") -> str:
     if direction == "stable":
         return "neutral"
@@ -314,7 +330,12 @@ def _count_sla_breaches(rows, as_of: datetime) -> int:
         created_at = _normalize_dt(getattr(row, "created_at", None))
         updated_at = _normalize_dt(getattr(row, "updated_at", None)) or created_at
         completed_at = _normalize_dt(getattr(row, "completed_at", None))
-        status = str(getattr(row, "status", "") or "").lower()
+        raw_status = getattr(row, "status", None)
+        status = canonical_request_status(
+            raw_status,
+            active_as="open",
+            fallback=str(raw_status or "").lower(),
+        )
         priority = str(getattr(row, "priority", "") or "").lower()
         owner_id = getattr(row, "owner_id", None)
 
@@ -933,12 +954,13 @@ def build_operational_report(
     )
 
     status_expr = func.coalesce(Request.status, "unknown").label("status_label")
-    by_status_rows = (
+    raw_status_rows = (
         base.with_entities(status_expr, func.count(Request.id))
         .group_by(status_expr)
         .order_by(func.count(Request.id).desc())
         .all()
     )
+    by_status_rows = _canonical_status_rows(raw_status_rows)
 
     assignment_rows = (
         base.filter(Request.owned_at.isnot(None))
@@ -1217,7 +1239,7 @@ def build_operational_report(
         },
         "breakdowns": {
             "by_category": _rows_by_label(by_category_rows, "category"),
-            "by_status": _rows_by_label(by_status_rows, "status"),
+            "by_status": by_status_rows,
         },
         "timeline": timeline,
         "items": report_items,

--- a/backend/helpchain_backend/src/services/request_sla.py
+++ b/backend/helpchain_backend/src/services/request_sla.py
@@ -17,6 +17,12 @@ from backend.models import (
 )
 from ..models.case import Case
 from ..models.case_event import CaseEvent
+from ..statuses import (
+    canonical_request_status,
+    is_terminal_request_status,
+    request_status_read_values,
+    request_terminal_status_read_values,
+)
 
 from .notification_jobs import enqueue_email_notification
 
@@ -40,10 +46,8 @@ DEFAULT_ESCALATION_THRESHOLD_HOURS = 72
 SLA_MARKER_COOLDOWN_HOURS = 24
 REQUEST_DASHBOARD_ACTIONABLE_STATUSES = (
     "new",
-    "open",
-    "in_progress",
-    "approved",
-    "pending",
+    *request_status_read_values("open", active_as="open"),
+    *request_status_read_values("in_progress", active_as="in_progress"),
 )
 
 # The repo currently has no dedicated SLA email template. Reuse an existing
@@ -51,14 +55,7 @@ REQUEST_DASHBOARD_ACTIONABLE_STATUSES = (
 # introducing template/UI changes in this pass.
 SLA_EMAIL_TEMPLATE = "emails/professional_lead_notify.html"
 
-_CLOSED_REQUEST_STATUSES = {
-    "done",
-    "completed",
-    "closed",
-    "cancelled",
-    "canceled",
-    "rejected",
-}
+_CLOSED_REQUEST_STATUSES = set(request_terminal_status_read_values())
 
 
 def _to_utc_naive(dt: datetime | None) -> datetime | None:
@@ -76,7 +73,12 @@ def _now_naive(now: datetime | None = None) -> datetime:
 
 
 def _request_status_value(request_obj: Request) -> str:
-    return ((getattr(request_obj, "status", None) or "").strip().lower() or "")
+    raw_status = getattr(request_obj, "status", None)
+    return canonical_request_status(
+        raw_status,
+        active_as="open",
+        fallback=((raw_status or "").strip().lower() or ""),
+    )
 
 
 def _is_open_request(request_obj: Request) -> bool:
@@ -84,7 +86,7 @@ def _is_open_request(request_obj: Request) -> bool:
         return False
     if bool(getattr(request_obj, "is_archived", False)):
         return False
-    return _request_status_value(request_obj) not in _CLOSED_REQUEST_STATUSES
+    return not is_terminal_request_status(getattr(request_obj, "status", None), active_as="open")
 
 
 def _request_label(request_obj: Request) -> str:

--- a/backend/helpchain_backend/src/statuses.py
+++ b/backend/helpchain_backend/src/statuses.py
@@ -27,15 +27,109 @@ REQUEST_STATUS_META = {
 
 REQUEST_STATUS_ALLOWED = set(REQUEST_STATUS_META.keys())
 REQUEST_STATUS_ORDER = ["open", "in_progress", "done", "cancelled"]
+REQUEST_CANONICAL_STATUS_ORDER = tuple(REQUEST_STATUS_ORDER)
 
-# Legacy aliases -> canonical statuses (no migrations)
+# Legacy write aliases -> canonical statuses (no migrations)
 REQUEST_STATUS_ALIASES = {
     "approved": "in_progress",  # legacy approved behaves like in_progress
     "rejected": "cancelled",  # legacy rejected behaves like cancelled
     "pending": "open",
 }
 
+# Read-time compatibility aliases. This layer intentionally normalizes legacy
+# vocabulary without rewriting stored DB values.
+REQUEST_STATUS_READ_ALIASES = {
+    "open": ("open", "pending"),
+    "in_progress": ("in_progress", "approved"),
+    "done": ("done", "completed", "resolved", "closed"),
+    "cancelled": ("cancelled", "canceled", "rejected"),
+}
+
+REQUEST_ACTIVE_READ_TARGETS = {"open", "in_progress"}
+
+
+def _clean_request_status(value: str | None) -> str:
+    return (value or "").strip().lower()
+
 
 def normalize_request_status(s: str | None) -> str:
-    s = (s or "").strip().lower()
+    s = _clean_request_status(s)
     return REQUEST_STATUS_ALIASES.get(s, s)
+
+
+def request_status_read_values(
+    canonical_status: str,
+    *,
+    active_as: str | None = None,
+) -> tuple[str, ...]:
+    key = _clean_request_status(canonical_status)
+    if key not in REQUEST_STATUS_ALLOWED:
+        return ()
+
+    values = list(REQUEST_STATUS_READ_ALIASES.get(key, (key,)))
+    if key == active_as:
+        values.append("active")
+
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        cleaned = _clean_request_status(value)
+        if cleaned and cleaned not in seen:
+            ordered.append(cleaned)
+            seen.add(cleaned)
+    return tuple(ordered)
+
+
+def canonical_request_status(
+    value: str | None,
+    *,
+    active_as: str = "open",
+    fallback: str | None = None,
+) -> str:
+    key = _clean_request_status(value)
+    if not key:
+        return fallback if fallback is not None else ""
+
+    if key == "active" and active_as in REQUEST_ACTIVE_READ_TARGETS:
+        return active_as
+
+    for canonical in REQUEST_CANONICAL_STATUS_ORDER:
+        if key in request_status_read_values(canonical, active_as=active_as):
+            return canonical
+
+    return fallback if fallback is not None else key
+
+
+def is_request_status(
+    value: str | None,
+    canonical_status: str,
+    *,
+    active_as: str = "open",
+) -> bool:
+    return canonical_request_status(value, active_as=active_as, fallback="") == _clean_request_status(
+        canonical_status
+    )
+
+
+def is_terminal_request_status(
+    value: str | None,
+    *,
+    active_as: str = "open",
+) -> bool:
+    return canonical_request_status(value, active_as=active_as, fallback="") in {
+        "done",
+        "cancelled",
+    }
+
+
+def request_terminal_status_read_values() -> tuple[str, ...]:
+    values = list(request_status_read_values("done"))
+    values.extend(request_status_read_values("cancelled"))
+
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if value not in seen:
+            ordered.append(value)
+            seen.add(value)
+    return tuple(ordered)

--- a/tests/test_operations_report.py
+++ b/tests/test_operations_report.py
@@ -225,6 +225,62 @@ def test_operations_report_priority_actions_and_territorial_pressure(app, db_sch
         assert report["territorial_pressure"]["zones"][0]["city"] == "Paris"
 
 
+def test_operations_report_normalizes_legacy_request_status_reads(app, db_schema):
+    now = datetime(2026, 5, 17, 12, 0, tzinfo=UTC)
+
+    with app.app_context():
+        structure = _make_structure("Compat Report")
+        _make_request(
+            structure_id=structure.id,
+            title="legacy pending",
+            status="pending",
+            created_at=now - timedelta(days=2),
+        )
+        _make_request(
+            structure_id=structure.id,
+            title="legacy active",
+            status="active",
+            created_at=now - timedelta(days=2),
+        )
+        _make_request(
+            structure_id=structure.id,
+            title="legacy approved",
+            status="approved",
+            created_at=now - timedelta(days=2),
+        )
+        _make_request(
+            structure_id=structure.id,
+            title="legacy resolved",
+            status="resolved",
+            created_at=now - timedelta(days=4),
+            completed_at=now - timedelta(days=1),
+        )
+        _make_request(
+            structure_id=structure.id,
+            title="legacy rejected",
+            status="rejected",
+            created_at=now - timedelta(days=3),
+        )
+        _make_request(
+            structure_id=structure.id,
+            title="unknown status",
+            status="queued_review",
+            created_at=now - timedelta(days=1),
+        )
+
+        report = build_operational_report(structure_id=structure.id, days=7, now=now)
+
+        assert report["requests"]["open"] == 4
+        assert report["requests"]["resolved"] == 1
+        assert report["breakdowns"]["by_status"] == [
+            {"status": "open", "count": 2},
+            {"status": "in_progress", "count": 1},
+            {"status": "done", "count": 1},
+            {"status": "cancelled", "count": 1},
+            {"status": "queued_review", "count": 1},
+        ]
+
+
 def test_operations_report_xlsx_workbook_structure(app, db_schema):
     from io import BytesIO
 

--- a/tests/test_ops_metrics_status_compat.py
+++ b/tests/test_ops_metrics_status_compat.py
@@ -1,0 +1,86 @@
+from datetime import UTC, datetime, timedelta
+
+from backend.extensions import db
+from backend.models import AdminUser, Request, Structure, User
+
+
+def _login_admin(client, admin_id: int) -> None:
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(admin_id)
+        sess["_fresh"] = True
+        sess["admin_user_id"] = admin_id
+        sess["admin_logged_in"] = True
+        sess["mfa_ok"] = True
+
+
+def test_ops_metrics_normalizes_legacy_request_status_reads(client, app):
+    now = datetime.now(UTC).replace(tzinfo=None, microsecond=0)
+
+    with app.app_context():
+        structure = Structure(name="Ops Compat", slug="ops-compat", status="active")
+        admin = AdminUser(
+            username="ops_compat_admin",
+            email="ops-compat-admin@test.local",
+            password_hash="x",
+            role="admin",
+            structure_id=None,
+            is_active=True,
+        )
+        user = User(
+            username="ops_compat_user",
+            email="ops-compat-user@test.local",
+            password_hash="x",
+            role="requester",
+            is_active=True,
+        )
+        db.session.add_all([structure, admin, user])
+        db.session.flush()
+        admin_id = admin.id
+
+        db.session.add_all(
+            [
+                Request(
+                    title="pending request",
+                    category="general",
+                    user_id=user.id,
+                    structure_id=structure.id,
+                    status="pending",
+                    created_at=now - timedelta(days=1),
+                ),
+                Request(
+                    title="active request",
+                    category="general",
+                    user_id=user.id,
+                    structure_id=structure.id,
+                    status="active",
+                    created_at=now - timedelta(days=1),
+                ),
+                Request(
+                    title="completed today",
+                    category="general",
+                    user_id=user.id,
+                    structure_id=structure.id,
+                    status="completed",
+                    completed_at=now,
+                    created_at=now - timedelta(days=2),
+                ),
+                Request(
+                    title="resolved today",
+                    category="general",
+                    user_id=user.id,
+                    structure_id=structure.id,
+                    status="resolved",
+                    completed_at=now,
+                    created_at=now - timedelta(days=2),
+                ),
+            ]
+        )
+        db.session.commit()
+
+    _login_admin(client, admin_id)
+    response = client.get("/admin/api/ops-metrics")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["active_requests"] == 2
+    assert data["resolved_today"] == 2

--- a/tests/test_request_sla_engine.py
+++ b/tests/test_request_sla_engine.py
@@ -378,6 +378,49 @@ def test_closed_completed_archived_and_deleted_requests_are_ignored(
     assert enqueue_calls == []
 
 
+def test_sla_read_normalization_treats_active_as_open_and_resolved_as_terminal(
+    sla_engine_session, enqueue_calls
+):
+    now = utc_now()
+    structure = _make_structure(sla_engine_session)
+    _make_admin(
+        sla_engine_session,
+        role="admin",
+        structure_id=structure.id,
+        email="compat-admin@test.local",
+    )
+    requester = _make_user(sla_engine_session, structure_id=structure.id)
+
+    active_req = _make_request(
+        sla_engine_session,
+        structure_id=structure.id,
+        user_id=requester.id,
+        owner_id=None,
+        status="active",
+        created_at=now - timedelta(hours=60),
+        updated_at=now - timedelta(hours=60),
+    )
+    _make_request(
+        sla_engine_session,
+        structure_id=structure.id,
+        user_id=requester.id,
+        owner_id=None,
+        status="resolved",
+        created_at=now - timedelta(hours=60),
+        updated_at=now - timedelta(hours=60),
+    )
+
+    stats = request_sla.process_request_sla(now=now)
+
+    assert stats["owner_reminders_enqueued"] == 1
+    assert len(enqueue_calls) == 1
+    assert _marker_count(
+        sla_engine_session,
+        request_id=active_req.id,
+        action=request_sla.SLA_OWNER_REMINDER_SENT,
+    ) == 1
+
+
 def test_recent_request_activity_prevents_stale_detection_even_when_created_is_old(
     sla_engine_session,
 ):

--- a/tests/test_request_statuses.py
+++ b/tests/test_request_statuses.py
@@ -1,0 +1,58 @@
+from backend.helpchain_backend.src.statuses import (
+    canonical_request_status,
+    is_terminal_request_status,
+    request_status_read_values,
+    request_terminal_status_read_values,
+)
+
+
+def test_canonical_request_status_maps_legacy_request_aliases():
+    assert canonical_request_status("pending") == "open"
+    assert canonical_request_status("approved") == "in_progress"
+    assert canonical_request_status("completed") == "done"
+    assert canonical_request_status("resolved") == "done"
+    assert canonical_request_status("closed") == "done"
+    assert canonical_request_status("rejected") == "cancelled"
+    assert canonical_request_status("canceled") == "cancelled"
+
+
+def test_canonical_request_status_resolves_active_by_context():
+    assert canonical_request_status("active", active_as="open") == "open"
+    assert canonical_request_status("active", active_as="in_progress") == "in_progress"
+
+
+def test_canonical_request_status_preserves_unknown_values_and_supports_fallback():
+    assert canonical_request_status("queued_review") == "queued_review"
+    assert canonical_request_status("queued_review", fallback="open") == "open"
+    assert canonical_request_status(None) == ""
+    assert canonical_request_status(None, fallback="open") == "open"
+
+
+def test_request_status_read_values_include_legacy_aliases():
+    assert request_status_read_values("open", active_as="open") == ("open", "pending", "active")
+    assert request_status_read_values("in_progress", active_as="in_progress") == (
+        "in_progress",
+        "approved",
+        "active",
+    )
+    assert request_status_read_values("done") == ("done", "completed", "resolved", "closed")
+    assert request_status_read_values("cancelled") == (
+        "cancelled",
+        "canceled",
+        "rejected",
+    )
+
+
+def test_terminal_status_helpers_cover_compatibility_values():
+    assert is_terminal_request_status("resolved")
+    assert is_terminal_request_status("rejected")
+    assert not is_terminal_request_status("approved")
+    assert request_terminal_status_read_values() == (
+        "done",
+        "completed",
+        "resolved",
+        "closed",
+        "cancelled",
+        "canceled",
+        "rejected",
+    )


### PR DESCRIPTION
## Summary
- adds centralized read-only Request status compatibility layer
- normalizes legacy Request status reads for SLA, reporting, queue buckets, and ops metrics
- preserves stored DB values and existing write behavior
- adds focused tests for canonical status resolution and legacy status compatibility

## Validation
- pytest status/SLA/reporting/ops metrics tests passed
- encoding guard passed
- git diff --check passed
