### PR TITLE
Protect tenant resolution contract

### DIFF
--- a/backend/core/tenant.py
+++ b/backend/core/tenant.py
@@ -25,6 +25,13 @@ def _is_test_env() -> bool:
 def _load_default_structure_id() -> int:
     global _DEFAULT_STRUCTURE_ID
     if _DEFAULT_STRUCTURE_ID is None:
+        # Legacy compatibility gate:
+        # - tests may bootstrap before schema creation
+        # - local/dev startup may warm tenant state before explicit scoping exists
+        #
+        # New request/admin/ops write flows should not depend on this branch long
+        # term. They should resolve a tenant explicitly and eventually fail closed
+        # before reaching the default-tenant fallback.
         allow_bootstrap = False
         if _is_test_env():
             allow_bootstrap = True
@@ -72,6 +79,20 @@ def _load_default_structure_id() -> int:
 
 
 def current_structure_id() -> int:
+    """Resolve the active tenant for the current runtime context.
+
+    Resolution order is part of the current compatibility contract:
+    1. ``g.structure_id`` when a caller has already bound an explicit tenant.
+    2. ``current_user.structure_id`` for authenticated request/admin flows.
+    3. ``g.user.structure_id`` for older request bootstrap paths.
+    4. ``_load_default_structure_id()`` as a documented legacy fallback.
+
+    The first three layers are the preferred runtime sources. Layer 4 exists to
+    preserve legacy tests, bootstrap/startup helpers, and older flows that still
+    assume an ambient default tenant. Future write paths and background entry
+    points should pass an explicit structure id or fail closed before relying on
+    the default tenant fallback.
+    """
     if not has_app_context():
         return _load_default_structure_id()
 

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -121,6 +121,11 @@ def utc_now() -> datetime:
 
 
 def _resolve_structure_id(structure_id: int | None = None) -> int:
+    # Background entry points should prefer an explicit structure_id from the
+    # caller. Falling back to current_structure_id() is legacy compatibility
+    # for in-process/task invocations that still inherit Flask context today.
+    # Future out-of-band producers should pass structure_id explicitly and fail
+    # closed when tenant resolution is unavailable.
     if structure_id:
         return int(structure_id)
     return int(current_structure_id())

--- a/tests/test_tenant_resolution_contract.py
+++ b/tests/test_tenant_resolution_contract.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from flask import g
+
+from backend.core import tenant
+from backend.models import Request, Structure, User
+
+
+def _make_user(session, *, email: str, structure_id: int | None = None) -> User:
+    user = User(
+        username=email.split("@", 1)[0],
+        email=email,
+        password_hash="x",
+        role="user",
+        is_active=True,
+        structure_id=structure_id,
+    )
+    session.add(user)
+    session.commit()
+    return user
+
+
+def test_current_structure_id_prefers_explicit_g_structure(app, session, monkeypatch):
+    with app.test_request_context("/"):
+        g.structure_id = 321
+        g.user = SimpleNamespace(structure_id=654)
+        monkeypatch.setattr(
+            tenant,
+            "current_user",
+            SimpleNamespace(is_authenticated=True, structure_id=987),
+        )
+
+        assert tenant.current_structure_id() == 321
+
+
+def test_current_structure_id_falls_back_to_current_user(app, session, monkeypatch):
+    structure = session.query(Structure).filter_by(slug="default").first()
+    assert structure is not None
+
+    with app.test_request_context("/"):
+        monkeypatch.setattr(
+            tenant,
+            "current_user",
+            SimpleNamespace(is_authenticated=True, structure_id=structure.id),
+        )
+
+        assert tenant.current_structure_id() == structure.id
+        assert g.structure_id == structure.id
+
+
+def test_current_structure_id_falls_back_to_g_user(app, session, monkeypatch):
+    structure = session.query(Structure).filter_by(slug="default").first()
+    assert structure is not None
+
+    with app.test_request_context("/"):
+        g.user = SimpleNamespace(structure_id=structure.id)
+        monkeypatch.setattr(
+            tenant,
+            "current_user",
+            SimpleNamespace(is_authenticated=False, structure_id=None),
+        )
+
+        assert tenant.current_structure_id() == structure.id
+        assert g.structure_id == structure.id
+
+
+def test_current_structure_id_uses_default_tenant_fallback(app, session, monkeypatch):
+    structure = session.query(Structure).filter_by(slug="default").first()
+    assert structure is not None
+    monkeypatch.setattr(tenant, "_DEFAULT_STRUCTURE_ID", None)
+
+    with app.test_request_context("/"):
+        monkeypatch.setattr(
+            tenant,
+            "current_user",
+            SimpleNamespace(is_authenticated=False, structure_id=None),
+        )
+
+        assert tenant.current_structure_id() == structure.id
+        assert g.structure_id == structure.id
+
+
+def test_current_structure_id_raises_when_all_resolution_layers_fail(
+    app, session, monkeypatch
+):
+    with app.test_request_context("/"):
+        monkeypatch.setattr(
+            tenant,
+            "current_user",
+            SimpleNamespace(is_authenticated=False, structure_id=None),
+        )
+
+        def _raise_runtime_error():
+            raise RuntimeError("tenant resolution unavailable")
+
+        monkeypatch.setattr(tenant, "_load_default_structure_id", _raise_runtime_error)
+
+        with pytest.raises(RuntimeError, match="tenant resolution unavailable"):
+            tenant.current_structure_id()
+
+
+def test_request_insert_uses_active_tenant_resolution(app, session, monkeypatch):
+    default_structure = session.query(Structure).filter_by(slug="default").first()
+    assert default_structure is not None
+
+    active_structure = Structure(name="Scoped", slug="scoped")
+    session.add(active_structure)
+    session.commit()
+
+    user = _make_user(
+        session,
+        email="tenant-request@test.local",
+        structure_id=default_structure.id,
+    )
+
+    monkeypatch.setattr(tenant, "current_structure_id", lambda: active_structure.id)
+
+    row = Request(title="Tenant contract", category="general", user_id=user.id)
+    session.add(row)
+    session.commit()
+
+    assert row.structure_id == active_structure.id
+
+
+def test_request_insert_falls_back_to_default_structure_when_resolver_fails(
+    app, session, monkeypatch
+):
+    default_structure = session.query(Structure).filter_by(slug="default").first()
+    assert default_structure is not None
+
+    user = _make_user(
+        session,
+        email="tenant-fallback@test.local",
+        structure_id=default_structure.id,
+    )
+
+    def _raise_runtime_error():
+        raise RuntimeError("no tenant context")
+
+    monkeypatch.setattr(tenant, "current_structure_id", _raise_runtime_error)
+
+    row = Request(title="Legacy fallback", category="general", user_id=user.id)
+    session.add(row)
+    session.commit()
+
+    assert row.structure_id == default_structure.id


### PR DESCRIPTION
## Summary
- adds tenant resolution contract tests
- documents legacy default-tenant fallback behavior
- documents background task tenant fallback as compatibility behavior
- preserves runtime behavior while preparing fail-closed hardening

## Validation
- tenant resolution and tenant isolation tests passed
- encoding guard passed
- git diff --check passed
