### PR TITLE
Restrict professional lead access to platform admins

### DIFF
--- a/backend/helpchain_backend/src/routes/admin.py
+++ b/backend/helpchain_backend/src/routes/admin.py
@@ -2679,6 +2679,17 @@ def _require_global_admin() -> None:
         abort(403)
 
 
+def _require_professional_lead_access() -> None:
+    # ProfessionalLead is intentionally platform-global. Keep operationally
+    # scoped admins out of the CRM surface while preserving founder access.
+    if _admin_role_value() != "superadmin":
+        _audit_denied_action(
+            required_roles={"platform_commercial", "superadmin"},
+            actor_role=_admin_role_value(),
+        )
+        abort(403)
+
+
 def _require_structure_admin_or_global() -> None:
     if not (_is_structure_admin() or _is_global_admin()):
         _audit_denied_action(
@@ -11540,7 +11551,9 @@ def admin_import_rollback(batch_id: int):
 @admin_bp.get("/professional-leads")
 @login_required
 @admin_required
+@admin_role_required("superadmin")
 def admin_professional_leads():
+    _require_professional_lead_access()
     empty_metrics = {
         "total": 0,
         "new": 0,
@@ -12108,7 +12121,9 @@ def _demo_lead_sla_state(lead: ProfessionalLead) -> str | None:
 @admin_bp.get("/professional-leads/demo")
 @login_required
 @admin_required
+@admin_role_required("superadmin")
 def admin_demo_leads():
+    _require_professional_lead_access()
     def _lead_age_meta(created_at, status_value: str | None):
         now_utc = datetime.now(UTC)
         if created_at is None:
@@ -12326,7 +12341,9 @@ def admin_demo_leads():
 @admin_bp.post("/professional-leads/<int:lead_id>/status")
 @login_required
 @admin_required
+@admin_role_required("superadmin")
 def admin_professional_lead_update_status(lead_id: int):
+    _require_professional_lead_access()
     allowed_statuses = {
         "new",
         "contacted",
@@ -12386,7 +12403,9 @@ def admin_professional_lead_update_status(lead_id: int):
 @admin_bp.post("/professional-leads/<int:lead_id>/notes")
 @login_required
 @admin_required
+@admin_role_required("superadmin")
 def admin_professional_lead_update_notes(lead_id: int):
+    _require_professional_lead_access()
     redirect_kwargs = {}
     for key in ("q", "profession", "city", "status", "queue"):
         value = (request.form.get(key) or "").strip()
@@ -12434,7 +12453,9 @@ def admin_professional_lead_update_notes(lead_id: int):
 @admin_bp.post("/professional-leads/<int:lead_id>/owner")
 @login_required
 @admin_required
+@admin_role_required("superadmin")
 def admin_professional_lead_update_owner(lead_id: int):
+    _require_professional_lead_access()
     redirect_kwargs = {}
     for key in ("q", "profession", "city", "status", "queue"):
         value = (request.form.get(key) or "").strip()
@@ -12512,7 +12533,9 @@ def admin_professional_lead_update_owner(lead_id: int):
 @admin_bp.post("/professional-leads/<int:lead_id>/contacted")
 @login_required
 @admin_required
+@admin_role_required("superadmin")
 def admin_professional_lead_mark_contacted(lead_id: int):
+    _require_professional_lead_access()
     if not _table_exists("professional_leads"):
         flash("Professional leads table is not available.", "warning")
         return redirect(url_for("admin.admin_professional_leads"), code=303)
@@ -12530,7 +12553,9 @@ def admin_professional_lead_mark_contacted(lead_id: int):
 @admin_bp.route("/professional-leads/<int:lead_id>", methods=["GET", "POST"])
 @login_required
 @admin_required
+@admin_role_required("superadmin")
 def admin_professional_lead_detail(lead_id: int):
+    _require_professional_lead_access()
     if not _table_exists("professional_leads"):
         flash("Professional leads table is not available.", "warning")
         return redirect(url_for("admin.admin_professional_leads"), code=303)
@@ -12575,7 +12600,9 @@ def admin_professional_lead_detail(lead_id: int):
 @admin_bp.get("/professionnels/leads")
 @login_required
 @admin_required
+@admin_role_required("superadmin")
 def admin_professionnels_leads():
+    _require_professional_lead_access()
     return redirect(url_for("admin.admin_professional_leads"), code=302)
 
 

--- a/templates/layouts/admin_workspace.html
+++ b/templates/layouts/admin_workspace.html
@@ -27,6 +27,8 @@
     {% set is_notifications_active = current_path.startswith('/ops/notifications') or current_path.startswith('/admin/notifications') %}
     {% set is_referrals_active = current_path.startswith('/admin/referrals') or (current_path.startswith('/admin/requests') and current_path.endswith('/refer')) %}
     {% set is_leads_active = current_path.startswith('/admin/professional-leads') %}
+    {% set admin_role = (current_user.role or '')|lower %}
+    {% set can_access_professional_leads = admin_role in ['superadmin', 'super_admin', 'super-admin'] %}
     {% set is_revenue_active = current_path.startswith('/admin/revenue') %}
     {% set is_conversion_active = current_path.startswith('/admin/conversion-dashboard') %}
 {% set is_reports_active = current_path.startswith('/admin/reports') %}
@@ -52,7 +54,9 @@
           <a class="hc-admin-shellnav__link {{ 'is-active' if is_cases_active else '' }}" href="{{ cases_href }}" {% if is_cases_active %}aria-current="page"{% endif %}>Cas</a>
           <a class="hc-admin-shellnav__link {{ 'is-active' if is_referrals_active else '' }}" href="{{ url_for('admin.admin_referrals_index') }}" {% if is_referrals_active %}aria-current="page"{% endif %}>Orientations partenaires</a>
           <a class="hc-admin-shellnav__link {{ 'is-active' if is_notifications_active else '' }}" href="{{ notifications_href }}" {% if is_notifications_active %}aria-current="page"{% endif %}>Notifications</a>
+          {% if can_access_professional_leads %}
           <a class="hc-admin-shellnav__link {{ 'is-active' if is_leads_active else '' }}" href="{{ url_for('admin.admin_professional_leads') }}" {% if is_leads_active %}aria-current="page"{% endif %}>Leads</a>
+          {% endif %}
           <a class="hc-admin-shellnav__link {{ 'is-active' if is_revenue_active else '' }}" href="{{ url_for('admin.admin_revenue') }}" {% if is_revenue_active %}aria-current="page"{% endif %}>Revenue</a>
           <a class="hc-admin-shellnav__link {{ 'is-active' if is_conversion_active else '' }}" href="/admin/conversion-dashboard" {% if is_conversion_active %}aria-current="page"{% endif %}>Conversion</a>
 <a class="hc-admin-shellnav__link {{ 'is-active' if is_reports_active else '' }}"

--- a/tests/test_professional_lead_access_control.py
+++ b/tests/test_professional_lead_access_control.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from backend.helpchain_backend.src.models import Case, ProfessionalLead
+from backend.models import AdminUser, Request, Structure, User, utc_now
+
+pytestmark = pytest.mark.spine
+
+
+def _login_admin(client, app, admin_user: AdminUser) -> None:
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(admin_user.id)
+        sess["user_id"] = admin_user.id
+        sess["admin_id"] = admin_user.id
+        sess["admin_user_id"] = admin_user.id
+        sess["role"] = admin_user.role
+        sess["is_authenticated"] = True
+        sess["is_admin"] = True
+        sess["admin_logged_in"] = True
+        sess["mfa_required"] = True
+        sess[app.config.get("MFA_SESSION_KEY", "mfa_ok")] = True
+        sess["mfa_ok_until"] = (utc_now() + timedelta(minutes=30)).isoformat()
+        sess["admin_mfa_last_verified"] = 4102444800
+        sess["admin_mfa_user_id"] = admin_user.id
+
+
+def _make_structure(session, *, name: str, slug: str) -> Structure:
+    row = Structure(name=name, slug=slug)
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _make_admin(
+    session,
+    *,
+    username: str,
+    email: str,
+    role: str,
+    structure_id: int | None,
+) -> AdminUser:
+    row = AdminUser(
+        username=username,
+        email=email,
+        password_hash="x",
+        role=role,
+        structure_id=structure_id,
+        is_active=True,
+        mfa_enabled=True,
+        totp_secret="professional-lead-access-test",
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _make_user(session, *, username: str, email: str, structure_id: int) -> User:
+    row = User(
+        username=username,
+        email=email,
+        password_hash="x",
+        role="requester",
+        is_active=True,
+        structure_id=structure_id,
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _make_request(
+    session,
+    *,
+    title: str,
+    user_id: int,
+    structure_id: int,
+) -> Request:
+    row = Request(
+        title=title,
+        description=f"Description for {title}",
+        category="general",
+        user_id=user_id,
+        structure_id=structure_id,
+        status="open",
+        priority="normal",
+        created_at=datetime.now(UTC).replace(tzinfo=None),
+        updated_at=datetime.now(UTC).replace(tzinfo=None),
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _seed_professional_lead_access_data(session):
+    structure_a = _make_structure(
+        session,
+        name="Lead Scope Alpha",
+        slug="lead-scope-alpha",
+    )
+    structure_b = _make_structure(
+        session,
+        name="Lead Scope Beta",
+        slug="lead-scope-beta",
+    )
+    structure_admin = _make_admin(
+        session,
+        username="lead_scope_structure_admin",
+        email="lead-scope-structure-admin@test.local",
+        role="admin",
+        structure_id=structure_a.id,
+    )
+    superadmin = _make_admin(
+        session,
+        username="lead_scope_superadmin",
+        email="lead-scope-superadmin@test.local",
+        role="superadmin",
+        structure_id=None,
+    )
+    user_a = _make_user(
+        session,
+        username="lead_scope_requester_a",
+        email="lead-scope-requester-a@test.local",
+        structure_id=structure_a.id,
+    )
+    request_a = _make_request(
+        session,
+        title="Lead-linked case request",
+        user_id=user_a.id,
+        structure_id=structure_a.id,
+    )
+    lead = ProfessionalLead(
+        email="global-lead@example.org",
+        full_name="Global Lead",
+        profession="Coordinatrice",
+        city="Paris",
+        source="demo_page",
+        status="new",
+    )
+    session.add(lead)
+    session.flush()
+    case_row = Case(
+        request_id=request_a.id,
+        structure_id=structure_a.id,
+        assigned_professional_lead_id=lead.id,
+        status="assigned",
+        priority="high",
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    session.add(case_row)
+    session.commit()
+    return structure_admin, superadmin, lead, request_a, case_row
+
+
+def test_structure_admin_cannot_access_professional_lead_surfaces_and_nav_is_hidden(app, session):
+    structure_admin, _superadmin, lead, _request_a, _case_row = _seed_professional_lead_access_data(
+        session
+    )
+    client = app.test_client()
+    _login_admin(client, app, structure_admin)
+
+    requests_page = client.get("/admin/requests")
+    assert requests_page.status_code == 200
+    assert 'href="/admin/professional-leads"' not in requests_page.get_data(as_text=True)
+
+    listing = client.get("/admin/professional-leads", follow_redirects=False)
+    assert listing.status_code == 403
+
+    demo_listing = client.get("/admin/professional-leads/demo", follow_redirects=False)
+    assert demo_listing.status_code == 403
+
+    detail = client.get(f"/admin/professional-leads/{lead.id}", follow_redirects=False)
+    assert detail.status_code == 403
+
+
+def test_structure_admin_cannot_edit_unrelated_professional_lead_detail(app, session):
+    structure_admin, _superadmin, lead, _request_a, _case_row = _seed_professional_lead_access_data(
+        session
+    )
+    client = app.test_client()
+    _login_admin(client, app, structure_admin)
+
+    response = client.post(
+        f"/admin/professional-leads/{lead.id}",
+        data={"status": "contacted", "notes": "Should not be allowed"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 403
+
+    session.refresh(lead)
+    assert lead.status == "new"
+    assert lead.contacted_at is None
+    assert (lead.notes or "") == ""
+
+
+def test_superadmin_keeps_global_professional_lead_access_and_nav(app, session):
+    _structure_admin, superadmin, lead, _request_a, _case_row = _seed_professional_lead_access_data(
+        session
+    )
+    client = app.test_client()
+    _login_admin(client, app, superadmin)
+
+    requests_page = client.get("/admin/requests")
+    assert requests_page.status_code == 200
+    assert 'href="/admin/professional-leads"' in requests_page.get_data(as_text=True)
+
+    listing = client.get("/admin/professional-leads")
+    assert listing.status_code == 200
+    assert "global-lead@example.org" in listing.get_data(as_text=True)
+
+    detail = client.get(f"/admin/professional-leads/{lead.id}")
+    assert detail.status_code == 200
+    assert "global-lead@example.org" in detail.get_data(as_text=True)
+
+    update = client.post(
+        f"/admin/professional-leads/{lead.id}",
+        data={"status": "contacted", "notes": "Founder review"},
+        follow_redirects=False,
+    )
+    assert update.status_code in (302, 303)
+
+    session.refresh(lead)
+    assert lead.status == "contacted"
+    assert lead.contacted_at is not None
+    assert "Founder review" in (lead.notes or "")
+
+
+def test_structure_admin_case_detail_still_renders_linked_professional_lead_reference(app, session):
+    structure_admin, _superadmin, _lead, _request_a, case_row = _seed_professional_lead_access_data(
+        session
+    )
+    client = app.test_client()
+    _login_admin(client, app, structure_admin)
+
+    response = client.get(f"/admin/cases/{case_row.id}")
+    html = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert "Global Lead" in html
+    assert "Lead-linked case request" in html


### PR DESCRIPTION
## Summary
- restricts ProfessionalLead admin browsing/editing to platform-level admins
- hides Leads navigation from structure-scoped admins
- preserves founder/global revenue analytics
- preserves operational linked-lead rendering

## Validation
- professional lead access-control tests passed
- professional lead premium tests passed
- revenue dashboard tests passed
- encoding guard passed
- git diff --check passed
