### PR TITLE
Harden case tenant consistency

### DIFF
--- a/backend/helpchain_backend/src/routes/admin.py
+++ b/backend/helpchain_backend/src/routes/admin.py
@@ -7154,13 +7154,13 @@ def admin_territorial_kpis():
         now = datetime.now(UTC).replace(tzinfo=None)
         since = now - timedelta(days=7)
 
-        case_filter = None
+        base_cases = (
+            db.session.query(Case)
+            .join(Request, Case.request_id == Request.id)
+            .filter(Case.structure_id == Request.structure_id)
+        )
         if not _is_global_admin():
-            case_filter = Case.structure_id == _current_structure_id()
-
-        base_cases = db.session.query(Case)
-        if case_filter is not None:
-            base_cases = base_cases.filter(case_filter)
+            base_cases = base_cases.filter(Request.structure_id == _current_structure_id())
 
         active_cases = (
             base_cases.filter(func.lower(Case.status) != "closed").count()
@@ -7196,18 +7196,29 @@ def admin_territorial_kpis():
                 )
             )
             .join(first_event_subq, Case.id == first_event_subq.c.case_id)
+            .join(Request, Case.request_id == Request.id)
+            .filter(Case.structure_id == Request.structure_id)
         )
-        if case_filter is not None:
-            avg_response_query = avg_response_query.filter(case_filter)
+        if not _is_global_admin():
+            avg_response_query = avg_response_query.filter(
+                Request.structure_id == _current_structure_id()
+            )
         avg_response_sec = avg_response_query.scalar()
         avg_response_hours = round(float(avg_response_sec or 0) / 3600.0, 2)
 
         open_filter = func.lower(Case.status) != "closed"
-        oldest_open_query = db.session.query(
-            func.max((func.julianday(now) - func.julianday(Case.created_at)) * 86400.0)
-        ).filter(open_filter)
-        if case_filter is not None:
-            oldest_open_query = oldest_open_query.filter(case_filter)
+        oldest_open_query = (
+            db.session.query(
+                func.max((func.julianday(now) - func.julianday(Case.created_at)) * 86400.0)
+            )
+            .join(Request, Case.request_id == Request.id)
+            .filter(Case.structure_id == Request.structure_id)
+            .filter(open_filter)
+        )
+        if not _is_global_admin():
+            oldest_open_query = oldest_open_query.filter(
+                Request.structure_id == _current_structure_id()
+            )
         oldest_open_sec = oldest_open_query.scalar()
         oldest_open_case_days = int(float(oldest_open_sec or 0) / 86400.0)
 
@@ -9127,6 +9138,7 @@ def _build_scoped_cases_base_query():
         Case.query.join(Request, Case.request_id == Request.id)
         .join(scoped_ids_subq, Request.id == scoped_ids_subq.c.id)
         .outerjoin(activity_sq, activity_sq.c.request_id == Request.id)
+        .filter(Case.structure_id == Request.structure_id)
     )
     case_filters = _build_case_kpi_filters(activity_expr_override=case_activity_expr)
     return query, case_filters
@@ -9489,11 +9501,12 @@ def _render_cases_list():
     no_owner_count = queue_counts["no_owner"]
     stale_count = queue_counts["stale_72h"]
 
-    owners = (
-        AdminUser.query.with_entities(AdminUser.id, AdminUser.username)
-        .order_by(AdminUser.username.asc())
-        .all()
-    )
+    owners_query = AdminUser.query.with_entities(AdminUser.id, AdminUser.username)
+    if not _is_global_admin():
+        owners_query = owners_query.filter(
+            AdminUser.structure_id == _current_structure_id()
+        )
+    owners = owners_query.order_by(AdminUser.username.asc()).all()
 
     return render_template(
         "admin/cases.html",

--- a/backend/helpchain_backend/src/routes/admin_cases.py
+++ b/backend/helpchain_backend/src/routes/admin_cases.py
@@ -305,6 +305,8 @@ def _get_scoped_case_or_404(case_id: int) -> tuple[Case, Request]:
         req = _scope_requests(Request.query).filter(Request.id == case_row.request_id).first()
     if not req:
         abort(404)
+    if getattr(case_row, "structure_id", None) != getattr(req, "structure_id", None):
+        abort(404)
     return case_row, req
 
 
@@ -433,9 +435,13 @@ def admin_case_detail(case_id: int):
         .all()
     )
     owners = _owner_query_for_current_scope().all()
+    legacy_users_query = User.query.with_entities(User.id, User.username, User.email)
+    if not _is_global_admin():
+        legacy_users_query = legacy_users_query.filter(
+            User.structure_id == getattr(case_row, "structure_id", None)
+        )
     legacy_users = (
-        User.query.with_entities(User.id, User.username, User.email)
-        .order_by(User.username.asc())
+        legacy_users_query.order_by(User.username.asc())
         .limit(300)
         .all()
     )
@@ -727,8 +733,17 @@ def admin_case_add_participant(case_id: int):
         except Exception:
             lead_id = None
 
-    if user_id is not None and not db.session.get(User, user_id):
+    selected_user = db.session.get(User, user_id) if user_id is not None else None
+    if user_id is not None and not selected_user:
         flash("Selected legacy user record does not exist.", "warning")
+        return redirect(
+            url_for("admin.admin_case_detail", case_id=case_row.id),
+            code=303,
+        )
+    if user_id is not None and getattr(selected_user, "structure_id", None) != getattr(
+        case_row, "structure_id", None
+    ):
+        flash("Selected user is outside this case structure.", "warning")
         return redirect(
             url_for("admin.admin_case_detail", case_id=case_row.id),
             code=303,

--- a/backend/helpchain_backend/src/routes/admin_map.py
+++ b/backend/helpchain_backend/src/routes/admin_map.py
@@ -213,6 +213,7 @@ def admin_risk_map_api():
         query = (
             Case.query.options(joinedload(Case.request))
             .join(Request, Case.request_id == Request.id)
+            .filter(Case.structure_id == Request.structure_id)
             .filter(func.lower(func.coalesce(Case.status, "")).in_(tuple(_ACTIVE_CASE_STATUSES)))
             .filter(
                 or_(
@@ -276,9 +277,23 @@ def admin_risk_map_api():
 
 @admin_map_bp.get("/api/cases/map")
 @admin_required
+@admin_role_required("readonly", "ops", "admin", "superadmin")
 def admin_cases_map_api():
     admin_required_404()
-    rows = _load_cases_with_geo()
+    scoped_request_ids = _scope_requests(Request.query.with_entities(Request.id)).subquery()
+    visible_case_ids = {
+        int(case_id)
+        for (case_id,) in (
+            db.session.query(Case.id)
+            .join(Request, Case.request_id == Request.id)
+            .join(scoped_request_ids, Request.id == scoped_request_ids.c.id)
+            .filter(Case.structure_id == Request.structure_id)
+            .all()
+        )
+    }
+    rows = [
+        row for row in _load_cases_with_geo() if int(getattr(row, "id", 0) or 0) in visible_case_ids
+    ]
     payload = []
     for row in rows:
         risk = compute_case_risk(int(row.id)) or {}

--- a/backend/helpchain_backend/src/routes/admin_risk.py
+++ b/backend/helpchain_backend/src/routes/admin_risk.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from flask import Blueprint, jsonify
 
 from backend.helpchain_backend.src.services.risk_engine import compute_case_risk
-from .admin import admin_required, admin_required_404
+from .admin import admin_required, admin_required_404, admin_role_required
+from .admin_cases import _get_scoped_case_or_404
 
 
 admin_risk_bp = Blueprint("admin_risk_api", __name__, url_prefix="/admin/api")
@@ -11,9 +12,11 @@ admin_risk_bp = Blueprint("admin_risk_api", __name__, url_prefix="/admin/api")
 
 @admin_risk_bp.get("/cases/<int:case_id>/risk")
 @admin_required
+@admin_role_required("readonly", "ops", "admin", "superadmin")
 def admin_case_risk(case_id: int):
     admin_required_404()
-    result = compute_case_risk(case_id)
+    case_row, _req = _get_scoped_case_or_404(case_id)
+    result = compute_case_risk(int(case_row.id))
     if result is None:
         return jsonify({"error": "case_not_found"}), 404
     return jsonify(result)

--- a/backend/helpchain_backend/src/routes/api.py
+++ b/backend/helpchain_backend/src/routes/api.py
@@ -16,6 +16,7 @@ from backend.ai_service import ai_service
 from ..controllers.helpchain_controller import HelpChainController
 from ..extensions import csrf
 from ..models import (
+    AdminUser,
     Case,
     CaseCollaborator,
     CaseEvent,
@@ -28,7 +29,7 @@ from ..models import (
     Structure,
     db,
 )
-from .admin import admin_required, admin_required_404, admin_role_required, _current_structure_id, _is_global_admin
+from .admin import admin_required, admin_required_404, admin_role_required, _is_global_admin
 from ..security.api_authz import require_api_auth, require_roles
 
 api_bp = Blueprint("api", __name__)
@@ -537,8 +538,20 @@ def invite_structure_to_case(case_id: int):
     if not case_row:
         return jsonify({"error": "case not found"}), 404
 
-    sid = _current_structure_id()
-    if not _is_global_admin() and sid and case_row.structure_id != sid:
+    admin_structure_id = getattr(current_user, "structure_id", None)
+    admin_user_id = (
+        session.get("admin_user_id")
+        or session.get("admin_id")
+        or session.get("user_id")
+    )
+    try:
+        if admin_user_id is not None:
+            admin_user = db.session.get(AdminUser, int(admin_user_id))
+            if admin_user is not None:
+                admin_structure_id = getattr(admin_user, "structure_id", None)
+    except Exception:
+        admin_structure_id = getattr(current_user, "structure_id", None)
+    if not _is_global_admin() and admin_structure_id is not None and case_row.structure_id != admin_structure_id:
         return jsonify({"error": "forbidden"}), 403
 
     if structure_id == case_row.structure_id:

--- a/tests/test_case_tenant_consistency.py
+++ b/tests/test_case_tenant_consistency.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from backend.extensions import db
+from backend.helpchain_backend.src.models import Case, CaseCollaborator, CaseParticipant
+from backend.models import AdminUser, Request, Structure, User, utc_now
+
+pytestmark = pytest.mark.spine
+
+
+def _login_admin(client, app, admin_user: AdminUser) -> None:
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(admin_user.id)
+        sess["user_id"] = admin_user.id
+        sess["admin_id"] = admin_user.id
+        sess["admin_user_id"] = admin_user.id
+        sess["role"] = admin_user.role
+        sess["is_authenticated"] = True
+        sess["is_admin"] = True
+        sess["admin_logged_in"] = True
+        sess["mfa_required"] = True
+        sess[app.config.get("MFA_SESSION_KEY", "mfa_ok")] = True
+        sess["mfa_ok_until"] = (utc_now() + timedelta(minutes=30)).isoformat()
+        sess["admin_mfa_last_verified"] = 4102444800
+        sess["admin_mfa_user_id"] = admin_user.id
+
+
+def _make_structure(session, *, name: str, slug: str) -> Structure:
+    row = Structure(name=name, slug=slug)
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _make_admin(
+    session,
+    *,
+    username: str,
+    email: str,
+    role: str,
+    structure_id: int | None,
+) -> AdminUser:
+    row = AdminUser(
+        username=username,
+        email=email,
+        password_hash="x",
+        role=role,
+        structure_id=structure_id,
+        is_active=True,
+        mfa_enabled=True,
+        totp_secret="case-tenant-consistency-test",
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _make_user(session, *, username: str, email: str, structure_id: int) -> User:
+    row = User(
+        username=username,
+        email=email,
+        password_hash="x",
+        role="requester",
+        is_active=True,
+        structure_id=structure_id,
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _make_request(
+    session,
+    *,
+    title: str,
+    user_id: int,
+    structure_id: int,
+    city: str = "Paris",
+) -> Request:
+    now = datetime.now(UTC).replace(tzinfo=None)
+    row = Request(
+        title=title,
+        description=f"Description for {title}",
+        category="general",
+        user_id=user_id,
+        structure_id=structure_id,
+        status="open",
+        city=city,
+        latitude=48.8566,
+        longitude=2.3522,
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _make_case(
+    session,
+    *,
+    request_id: int,
+    structure_id: int,
+    title_hint: str,
+    latitude: float = 48.8566,
+    longitude: float = 2.3522,
+) -> Case:
+    now = datetime.now(UTC)
+    row = Case(
+        request_id=request_id,
+        structure_id=structure_id,
+        status="new",
+        priority="high",
+        risk_score=75,
+        latitude=latitude,
+        longitude=longitude,
+        opened_at=now,
+        last_activity_at=now,
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _seed_case_scope(session):
+    structure_a = _make_structure(
+        session,
+        name="Case Tenant Alpha",
+        slug="case-tenant-alpha",
+    )
+    structure_b = _make_structure(
+        session,
+        name="Case Tenant Beta",
+        slug="case-tenant-beta",
+    )
+    structure_c = _make_structure(
+        session,
+        name="Case Tenant Gamma",
+        slug="case-tenant-gamma",
+    )
+    admin_a = _make_admin(
+        session,
+        username="case_tenant_admin_a",
+        email="case-tenant-admin-a@test.local",
+        role="admin",
+        structure_id=structure_a.id,
+    )
+    admin_b = _make_admin(
+        session,
+        username="case_tenant_admin_b",
+        email="case-tenant-admin-b@test.local",
+        role="admin",
+        structure_id=structure_b.id,
+    )
+    ops_a = _make_admin(
+        session,
+        username="case_tenant_ops_a",
+        email="case-tenant-ops-a@test.local",
+        role="ops",
+        structure_id=structure_a.id,
+    )
+    user_a = _make_user(
+        session,
+        username="case_tenant_user_a",
+        email="case-tenant-user-a@test.local",
+        structure_id=structure_a.id,
+    )
+    user_b = _make_user(
+        session,
+        username="case_tenant_user_b",
+        email="case-tenant-user-b@test.local",
+        structure_id=structure_b.id,
+    )
+    request_a = _make_request(
+        session,
+        title="tenant-a-case-visible",
+        user_id=user_a.id,
+        structure_id=structure_a.id,
+        city="Boulogne",
+    )
+    request_b = _make_request(
+        session,
+        title="tenant-b-case-hidden",
+        user_id=user_b.id,
+        structure_id=structure_b.id,
+        city="Nanterre",
+    )
+    request_b_mismatch = _make_request(
+        session,
+        title="tenant-b-case-mismatch",
+        user_id=user_b.id,
+        structure_id=structure_b.id,
+        city="Courbevoie",
+    )
+    visible_case = _make_case(
+        session,
+        request_id=request_a.id,
+        structure_id=structure_a.id,
+        title_hint="visible",
+    )
+    hidden_case = _make_case(
+        session,
+        request_id=request_b.id,
+        structure_id=structure_b.id,
+        title_hint="hidden",
+    )
+    inconsistent_case = _make_case(
+        session,
+        request_id=request_b_mismatch.id,
+        structure_id=structure_a.id,
+        title_hint="inconsistent",
+        latitude=48.9,
+        longitude=2.4,
+    )
+    session.commit()
+    return {
+        "structure_a": structure_a,
+        "structure_b": structure_b,
+        "structure_c": structure_c,
+        "admin_a": admin_a,
+        "admin_b": admin_b,
+        "ops_a": ops_a,
+        "user_a": user_a,
+        "user_b": user_b,
+        "request_a": request_a,
+        "request_b": request_b,
+        "request_b_mismatch": request_b_mismatch,
+        "visible_case": visible_case,
+        "hidden_case": hidden_case,
+        "inconsistent_case": inconsistent_case,
+    }
+
+
+def test_open_case_from_request_keeps_case_and_request_structure_in_sync(app, session):
+    structure = _make_structure(session, name="Open Case Scope", slug="open-case-scope")
+    admin = _make_admin(
+        session,
+        username="open_case_ops",
+        email="open-case-ops@test.local",
+        role="ops",
+        structure_id=structure.id,
+    )
+    user = _make_user(
+        session,
+        username="open_case_user",
+        email="open-case-user@test.local",
+        structure_id=structure.id,
+    )
+    req = _make_request(
+        session,
+        title="open-case-request",
+        user_id=user.id,
+        structure_id=structure.id,
+    )
+    session.commit()
+
+    client = app.test_client()
+    _login_admin(client, app, admin)
+
+    response = client.post(f"/admin/requests/{req.id}/open-case", follow_redirects=False)
+    case_row = Case.query.filter_by(request_id=req.id).one()
+
+    assert response.status_code == 303
+    assert case_row.structure_id == req.structure_id
+
+
+def test_inconsistent_case_is_hidden_from_case_views_and_kpis(app, session):
+    seeded = _seed_case_scope(session)
+    client = app.test_client()
+    _login_admin(client, app, seeded["admin_a"])
+
+    listing = client.get("/admin/cases")
+    assert listing.status_code == 200
+    html = listing.get_data(as_text=True)
+    assert "tenant-a-case-visible" in html
+    assert "tenant-b-case-hidden" not in html
+
+    inconsistent_detail = client.get(
+        f"/admin/cases/{seeded['inconsistent_case'].id}",
+        follow_redirects=False,
+    )
+    assert inconsistent_detail.status_code == 404
+
+    territorial = client.get("/admin/api/territorial-kpis")
+    assert territorial.status_code == 200
+    payload = territorial.get_json()
+    assert payload["active_cases"] == 1
+    assert payload["new_cases_week"] == 1
+
+
+def test_cross_tenant_case_participant_user_attachment_is_rejected(app, session):
+    seeded = _seed_case_scope(session)
+    client = app.test_client()
+    _login_admin(client, app, seeded["admin_a"])
+
+    response = client.post(
+        f"/admin/cases/{seeded['visible_case'].id}/participants",
+        data={
+            "participant_type": "admin_user",
+            "role": "contributor",
+            "status": "active",
+            "user_id": str(seeded["user_b"].id),
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    participant = (
+        CaseParticipant.query.filter(CaseParticipant.case_id == seeded["visible_case"].id)
+        .filter(CaseParticipant.user_id == seeded["user_b"].id)
+        .first()
+    )
+    assert participant is None
+
+
+def test_case_map_and_risk_api_are_tenant_scoped(app, session):
+    seeded = _seed_case_scope(session)
+    client = app.test_client()
+    _login_admin(client, app, seeded["admin_a"])
+
+    map_response = client.get("/admin/api/cases/map")
+    assert map_response.status_code == 200
+    case_ids = {int(row["id"]) for row in map_response.get_json()["cases"]}
+    assert seeded["visible_case"].id in case_ids
+    assert seeded["hidden_case"].id not in case_ids
+    assert seeded["inconsistent_case"].id not in case_ids
+
+    own_risk = client.get(f"/admin/api/cases/{seeded['visible_case'].id}/risk")
+    assert own_risk.status_code == 200
+
+    hidden_risk = client.get(f"/admin/api/cases/{seeded['hidden_case'].id}/risk")
+    assert hidden_risk.status_code == 404
+
+    inconsistent_risk = client.get(
+        f"/admin/api/cases/{seeded['inconsistent_case'].id}/risk"
+    )
+    assert inconsistent_risk.status_code == 404
+
+
+def test_case_collaborator_invite_is_controlled_by_case_owner_scope(app, session):
+    seeded = _seed_case_scope(session)
+
+    owner_client = app.test_client()
+    _login_admin(owner_client, app, seeded["ops_a"])
+
+    invited = owner_client.post(
+        f"/api/cases/{seeded['visible_case'].id}/invite-structure",
+        json={"structure_id": seeded["structure_b"].id, "role": "viewer"},
+    )
+    assert invited.status_code == 200
+    collaborator = (
+        CaseCollaborator.query.filter(CaseCollaborator.case_id == seeded["visible_case"].id)
+        .filter(CaseCollaborator.structure_id == seeded["structure_b"].id)
+        .first()
+    )
+    assert collaborator is not None
+
+    foreign_client = app.test_client()
+    _login_admin(foreign_client, app, seeded["admin_b"])
+    denied = foreign_client.post(
+        f"/api/cases/{seeded['visible_case'].id}/invite-structure",
+        json={"structure_id": seeded["structure_c"].id, "role": "viewer"},
+    )
+    assert denied.status_code == 403


### PR DESCRIPTION
## Summary
- enforces Case.structure_id and Request.structure_id consistency on operational paths
- hides structurally inconsistent cases from scoped views and KPIs
- rejects cross-tenant participant attachment
- tenant-scopes case map and case risk APIs
- hardens collaborator invite authority checks

## Validation
- case tenant consistency tests passed
- tenant leak regression tests passed
- admin map API tests passed
- risk engine tests passed
- encoding guard passed
- git diff --check passed
