### PR TITLE
Harden tenant-scoped legacy exports

### DIFF
--- a/backend/helpchain_backend/src/controllers/helpchain_controller.py
+++ b/backend/helpchain_backend/src/controllers/helpchain_controller.py
@@ -178,13 +178,26 @@ class HelpChainController:
 
         return out
 
-    def export_requests(self, filters, fmt="excel"):
+    def export_requests(
+        self,
+        filters,
+        fmt="excel",
+        *,
+        structure_id: int | None = None,
+        allow_global: bool = False,
+    ):
         if not MODELS_AVAILABLE:
             raise RuntimeError(
                 "Models HelpRequest/Volunteer not found. Add them under src/models/ to enable export."
             )
 
         q = db.session.query(HelpRequest)
+        if allow_global:
+            pass
+        elif structure_id is not None:
+            q = q.filter(HelpRequest.structure_id == int(structure_id))
+        else:
+            raise PermissionError("tenant scope required for export")
         q = self._apply_filters_query(q, filters)
         rows = []
         for r in q.all():
@@ -201,28 +214,55 @@ class HelpChainController:
                 }
             )
 
-        # pandas lazy import
-        try:
-            import pandas as pd  # local import
-        except Exception as e:
-            raise RuntimeError(
-                "pandas is required for export_requests. Install with: pip install pandas openpyxl"
-            ) from e
-
-        df = pd.DataFrame(rows)
-
         tmpdir = tempfile.gettempdir()
         if fmt == "excel":
+            try:
+                import pandas as pd  # local import
+            except Exception:
+                pd = None
+
             path = os.path.join(
                 tmpdir, f"help_requests_{int(utc_now().timestamp())}.xlsx"
             )
-            df.to_excel(path, index=False, engine="openpyxl")
+            if pd is not None:
+                df = pd.DataFrame(rows)
+                df.to_excel(path, index=False, engine="openpyxl")
+            else:
+                try:
+                    from openpyxl import Workbook
+                except Exception as e:
+                    raise RuntimeError(
+                        "openpyxl is required for excel export. Install with: pip install openpyxl"
+                    ) from e
+                workbook = Workbook()
+                sheet = workbook.active
+                headers = [
+                    "id",
+                    "title",
+                    "status",
+                    "type",
+                    "region",
+                    "volunteer",
+                    "created_at",
+                    "updated_at",
+                ]
+                sheet.append(headers)
+                for row in rows:
+                    sheet.append([row.get(header) for header in headers])
+                workbook.save(path)
             return (
                 path,
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
                 os.path.basename(path),
             )
         elif fmt == "pdf":
+            try:
+                import pandas as pd  # local import
+            except Exception as e:
+                raise RuntimeError(
+                    "pandas is required for export_requests. Install with: pip install pandas openpyxl"
+                ) from e
+            df = pd.DataFrame(rows)
             try:
                 from jinja2 import Template
                 from weasyprint import HTML

--- a/backend/helpchain_backend/src/routes/admin.py
+++ b/backend/helpchain_backend/src/routes/admin.py
@@ -8452,6 +8452,9 @@ def edit_volunteer(id):
 def export_volunteers():
     admin_required_404()
     """Export volunteers as CSV."""
+    _require_global_admin()
+    if getattr(current_user, "structure_id", None) is not None:
+        abort(403)
     if not current_user.is_admin:
         flash(_("Access denied."), "error")
         return redirect(url_for("main.index"))

--- a/backend/helpchain_backend/src/routes/api.py
+++ b/backend/helpchain_backend/src/routes/api.py
@@ -28,6 +28,7 @@ from ..models import (
     RequestMetric,
     Structure,
     db,
+    canonical_role,
 )
 from .admin import admin_required, admin_required_404, admin_role_required, _is_global_admin
 from ..security.api_authz import require_api_auth, require_roles
@@ -746,10 +747,28 @@ def export():
         for k in ("date_from", "date_to", "status", "region", "volunteer_id")
     }
     try:
-        path, mimetype, filename = controller.export_requests(filters, fmt)
+        actor_id = getattr(g, "api_user_id", None)
+        actor = db.session.get(AdminUser, int(actor_id)) if actor_id else None
+        if actor is None or not bool(getattr(actor, "is_active", False)):
+            return jsonify({"error": "Forbidden"}), 403
+
+        role = canonical_role(getattr(actor, "role", None))
+        is_global_admin = role == "superadmin" and getattr(actor, "structure_id", None) is None
+        structure_id = None if is_global_admin else getattr(actor, "structure_id", None)
+        if not is_global_admin and structure_id is None:
+            return jsonify({"error": "Forbidden"}), 403
+
+        path, mimetype, filename = controller.export_requests(
+            filters,
+            fmt,
+            structure_id=structure_id,
+            allow_global=is_global_admin,
+        )
         return send_file(
             path, mimetype=mimetype, as_attachment=True, download_name=filename
         )
+    except PermissionError:
+        return jsonify({"error": "Forbidden"}), 403
     except NotImplementedError:
         return jsonify({"error": "format not supported"}), 400
     except RuntimeError as e:

--- a/tests/test_tenant_leak_regressions.py
+++ b/tests/test_tenant_leak_regressions.py
@@ -215,6 +215,108 @@ def test_cross_tenant_request_visibility_export_and_detail_are_scoped(app, sessi
     assert "tenant-b-request-hidden" not in export_text
 
 
+def test_cross_tenant_request_export_xlsx_matches_listing_scope(app, session):
+    from openpyxl import load_workbook
+
+    structure_a, structure_b, admin, user_a, user_b = _seed_scoped_admin(
+        session, prefix="request_xlsx_scope"
+    )
+    _make_request(
+        session,
+        title="tenant-a-xlsx-visible",
+        user_id=user_a.id,
+        structure_id=structure_a.id,
+        status="pending",
+    )
+    _make_request(
+        session,
+        title="tenant-b-xlsx-hidden",
+        user_id=user_b.id,
+        structure_id=structure_b.id,
+        status="pending",
+    )
+    session.commit()
+
+    client = app.test_client()
+    _login_admin(client, app, admin)
+
+    listing = client.get("/admin/requests")
+    assert listing.status_code == 200
+    listing_html = listing.get_data(as_text=True)
+    assert "tenant-a-xlsx-visible" in listing_html
+    assert "tenant-b-xlsx-hidden" not in listing_html
+
+    export_xlsx = client.get("/admin/requests/export.xlsx")
+    assert export_xlsx.status_code == 200
+
+    workbook = load_workbook(BytesIO(export_xlsx.get_data()))
+    sheet = workbook.active
+    values = {
+        str(cell)
+        for row in sheet.iter_rows(values_only=True)
+        for cell in row
+        if cell is not None
+    }
+    assert "tenant-a-xlsx-visible" in values
+    assert "tenant-b-xlsx-hidden" not in values
+
+
+def test_cross_tenant_legacy_api_export_is_scoped(app, session):
+    from backend.helpchain_backend.src.jwt_utils import encode_access_token
+    from openpyxl import load_workbook
+
+    structure_a, structure_b, admin, user_a, user_b = _seed_scoped_admin(
+        session, prefix="legacy_api_export_scope"
+    )
+    _make_request(
+        session,
+        title="tenant-a-api-export-visible",
+        user_id=user_a.id,
+        structure_id=structure_a.id,
+        status="pending",
+    )
+    _make_request(
+        session,
+        title="tenant-b-api-export-hidden",
+        user_id=user_b.id,
+        structure_id=structure_b.id,
+        status="pending",
+    )
+    session.commit()
+
+    with app.app_context():
+        token = encode_access_token(admin.id)
+
+    client = app.test_client()
+    response = client.get(
+        "/api/export?format=excel",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+
+    workbook = load_workbook(BytesIO(response.get_data()))
+    sheet = workbook.active
+    values = {
+        str(cell)
+        for row in sheet.iter_rows(values_only=True)
+        for cell in row
+        if cell is not None
+    }
+    assert "tenant-a-api-export-visible" in values
+    assert "tenant-b-api-export-hidden" not in values
+
+
+def test_structure_scoped_admin_cannot_use_global_volunteer_export(app, session):
+    _structure_a, _structure_b, admin, _user_a, _user_b = _seed_scoped_admin(
+        session, prefix="volunteer_export_scope"
+    )
+    client = app.test_client()
+    _login_admin(client, app, admin)
+
+    response = client.get("/admin/export_volunteers")
+    assert response.status_code == 403
+
+
 def test_cross_tenant_case_visibility_and_mutation_are_scoped(app, session):
     structure_a, structure_b, admin, user_a, user_b = _seed_scoped_admin(
         session, prefix="case_scope"


### PR DESCRIPTION
## Summary
- hardens legacy /api/export tenant scoping
- prevents scoped admins from using legacy volunteer global export
- preserves superadmin/global export behavior where intentional
- adds tenant export regression coverage

## Validation
- tenant leak regression tests passed
- encoding guard passed
- git diff --check passed
