### PR TITLE
Introduce first admin policy helpers

### DIFF
--- a/backend/helpchain_backend/src/admin_policies.py
+++ b/backend/helpchain_backend/src/admin_policies.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .admin_actor import AdminActor
+
+
+def can_access_professional_leads(actor: "AdminActor | None") -> bool:
+    return bool(actor and actor.has_founder_global_access)
+
+
+def can_view_global_analytics(actor: "AdminActor | None") -> bool:
+    return bool(actor and actor.has_founder_global_access)
+
+
+def can_export_operational_data(
+    actor: "AdminActor | None", structure_id: int | None = None
+) -> bool:
+    if not actor or not actor.is_authenticated or not actor.is_admin:
+        return False
+    if actor.is_platform_global:
+        return True
+
+    tenant_scope_id = actor.tenant_scope_id
+    if tenant_scope_id is None:
+        return False
+    if structure_id is None:
+        return True
+
+    try:
+        return int(tenant_scope_id) == int(structure_id)
+    except (TypeError, ValueError):
+        return False
+
+
+def can_mutate_request(actor: "AdminActor | None", request) -> bool:
+    if not actor or not request or not actor.is_authenticated or not actor.is_admin:
+        return False
+    if actor.is_platform_global:
+        return True
+
+    tenant_scope_id = actor.tenant_scope_id
+    request_structure_id = getattr(request, "structure_id", None)
+    if tenant_scope_id is None or request_structure_id is None:
+        return False
+
+    try:
+        return int(tenant_scope_id) == int(request_structure_id)
+    except (TypeError, ValueError):
+        return False

--- a/backend/helpchain_backend/src/routes/admin.py
+++ b/backend/helpchain_backend/src/routes/admin.py
@@ -53,6 +53,7 @@ from backend.audit import log_activity
 from backend.extensions import db, limiter, mail
 from backend.system_sanity import run_system_checks
 from ..admin_actor import resolve_current_admin_actor
+from ..admin_policies import can_access_professional_leads
 from ..models.volunteer_interest import VolunteerInterest
 from ..observability import (
     tenant_leak_get,
@@ -2681,7 +2682,7 @@ def _require_professional_lead_access() -> None:
     # ProfessionalLead is intentionally platform-global. Keep operationally
     # scoped admins out of the CRM surface while preserving founder access.
     actor = resolve_current_admin_actor()
-    if not actor.has_founder_global_access:
+    if not can_access_professional_leads(actor):
         _audit_denied_action(
             required_roles={"platform_commercial", "superadmin"},
             actor_role=actor.role,

--- a/backend/helpchain_backend/src/routes/api.py
+++ b/backend/helpchain_backend/src/routes/api.py
@@ -14,6 +14,7 @@ from werkzeug.security import check_password_hash
 from backend.ai_service import ai_service
 
 from ..admin_actor import resolve_bearer_admin_actor, resolve_current_admin_actor
+from ..admin_policies import can_mutate_request
 from ..controllers.helpchain_controller import HelpChainController
 from ..extensions import csrf
 from ..models import (
@@ -824,9 +825,14 @@ def change_status():
         if not request_id or not new_status:
             return jsonify({"success": False, "message": "Invalid data"}), 400
 
-        _actor, scoped_query = _session_admin_request_scope()
-        req = scoped_query.filter(Request.id == int(request_id)).first()
-        if not req:
+        actor = resolve_current_admin_actor()
+        if not actor.is_authenticated or not actor.is_admin:
+            raise PermissionError("inactive or missing admin actor")
+        if not actor.is_platform_global and actor.tenant_scope_id is None:
+            raise PermissionError("tenant-scoped admin missing structure")
+
+        req = Request.query.filter(Request.id == int(request_id)).first()
+        if not req or not can_mutate_request(actor, req):
             return jsonify({"success": False, "message": "Request not found"}), 404
 
         req.status = new_status
@@ -869,9 +875,14 @@ def delete_request():
         if not request_id:
             return jsonify({"success": False, "message": "Invalid request ID"}), 400
 
-        _actor, scoped_query = _session_admin_request_scope()
-        req = scoped_query.filter(Request.id == int(request_id)).first()
-        if not req:
+        actor = resolve_current_admin_actor()
+        if not actor.is_authenticated or not actor.is_admin:
+            raise PermissionError("inactive or missing admin actor")
+        if not actor.is_platform_global and actor.tenant_scope_id is None:
+            raise PermissionError("tenant-scoped admin missing structure")
+
+        req = Request.query.filter(Request.id == int(request_id)).first()
+        if not req or not can_mutate_request(actor, req):
             return jsonify({"success": False, "message": "Request not found"}), 404
 
         # Delete logs first

--- a/tests/test_admin_policies.py
+++ b/tests/test_admin_policies.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from backend.helpchain_backend.src.admin_actor import AdminActor
+from backend.helpchain_backend.src.admin_policies import (
+    can_access_professional_leads,
+    can_export_operational_data,
+    can_mutate_request,
+    can_view_global_analytics,
+)
+
+
+def _actor(
+    *,
+    role: str | None,
+    structure_id: int | None,
+    is_authenticated: bool = True,
+    is_platform_global: bool = False,
+) -> AdminActor:
+    return AdminActor(
+        admin_id=1 if is_authenticated else None,
+        role=role,
+        structure_id=structure_id,
+        is_authenticated=is_authenticated,
+        is_platform_global=is_platform_global,
+        auth_source="test",
+        raw_admin=None,
+    )
+
+
+def test_professional_lead_and_global_analytics_helpers_match_founder_access():
+    structure_admin = _actor(role="admin", structure_id=12)
+    founder_global = _actor(role="superadmin", structure_id=None, is_platform_global=True)
+    founder_scoped = _actor(role="superadmin", structure_id=12, is_platform_global=False)
+
+    assert can_access_professional_leads(structure_admin) is False
+    assert can_view_global_analytics(structure_admin) is False
+
+    assert can_access_professional_leads(founder_global) is True
+    assert can_view_global_analytics(founder_global) is True
+
+    assert can_access_professional_leads(founder_scoped) is True
+    assert can_view_global_analytics(founder_scoped) is True
+
+
+def test_operational_export_helper_respects_admin_scope():
+    anonymous = _actor(role=None, structure_id=None, is_authenticated=False)
+    structure_admin = _actor(role="admin", structure_id=12)
+    founder_global = _actor(role="superadmin", structure_id=None, is_platform_global=True)
+
+    assert can_export_operational_data(anonymous) is False
+    assert can_export_operational_data(structure_admin) is True
+    assert can_export_operational_data(structure_admin, structure_id=12) is True
+    assert can_export_operational_data(structure_admin, structure_id=99) is False
+    assert can_export_operational_data(founder_global) is True
+    assert can_export_operational_data(founder_global, structure_id=99) is True
+
+
+def test_request_mutation_helper_respects_request_tenant_scope():
+    structure_admin = _actor(role="admin", structure_id=12)
+    founder_global = _actor(role="superadmin", structure_id=None, is_platform_global=True)
+
+    visible_request = SimpleNamespace(id=101, structure_id=12)
+    hidden_request = SimpleNamespace(id=202, structure_id=99)
+    unscoped_request = SimpleNamespace(id=303, structure_id=None)
+
+    assert can_mutate_request(structure_admin, visible_request) is True
+    assert can_mutate_request(structure_admin, hidden_request) is False
+    assert can_mutate_request(structure_admin, unscoped_request) is False
+    assert can_mutate_request(founder_global, visible_request) is True
+    assert can_mutate_request(founder_global, hidden_request) is True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -474,3 +474,35 @@ def test_legacy_admin_change_status_stays_tenant_scoped(app, session):
     session.refresh(req_b)
     assert req_a.status == "done"
     assert req_b.status == "pending"
+
+
+def test_legacy_admin_delete_request_requires_admin_session(client):
+    response = client.post(
+        "/api/admin/delete_request",
+        json={"request_id": 1},
+    )
+
+    assert response.status_code == 403
+
+
+def test_legacy_admin_delete_request_stays_tenant_scoped(app, session):
+    _structure_a, _structure_b, admin_a, req_a, req_b = _seed_admin_api_scope(
+        session, prefix="tracked_api_delete_request_scope"
+    )
+    client = app.test_client()
+    _login_admin(client, app, admin_a)
+
+    own_response = client.post(
+        "/api/admin/delete_request",
+        json={"request_id": req_a.id},
+    )
+    hidden_response = client.post(
+        "/api/admin/delete_request",
+        json={"request_id": req_b.id},
+    )
+
+    assert own_response.status_code == 200
+    assert hidden_response.status_code == 404
+
+    assert session.get(Request, req_a.id) is None
+    assert session.get(Request, req_b.id) is not None


### PR DESCRIPTION
## Summary
- adds first centralized admin policy helpers
- migrates ProfessionalLead access guard to policy helper
- migrates legacy request mutation checks to policy helper
- preserves existing behavior

## Validation
- admin policy tests passed
- API tests passed
- professional lead access-control tests passed
- tenant leak regression tests passed
- encoding guard passed
- git diff --check passed
