### PR TITLE
Use policy helper for global analytics guards

### DIFF
--- a/backend/helpchain_backend/src/routes/admin.py
+++ b/backend/helpchain_backend/src/routes/admin.py
@@ -54,6 +54,7 @@ from backend.extensions import db, limiter, mail
 from backend.system_sanity import run_system_checks
 from ..admin_actor import resolve_current_admin_actor
 from ..admin_policies import can_access_professional_leads
+from ..admin_policies import can_view_global_analytics
 from ..models.volunteer_interest import VolunteerInterest
 from ..observability import (
     tenant_leak_get,
@@ -2685,6 +2686,16 @@ def _require_professional_lead_access() -> None:
     if not can_access_professional_leads(actor):
         _audit_denied_action(
             required_roles={"platform_commercial", "superadmin"},
+            actor_role=actor.role,
+        )
+        abort(403)
+
+
+def _require_global_analytics_access() -> None:
+    actor = resolve_current_admin_actor()
+    if not can_view_global_analytics(actor):
+        _audit_denied_action(
+            required_roles={"global_analytics"},
             actor_role=actor.role,
         )
         abort(403)
@@ -10970,7 +10981,7 @@ def _revenue_focus(rows: list[SimpleNamespace]) -> dict:
 @admin_required
 @admin_role_required("superadmin")
 def admin_revenue():
-    _require_global_admin()
+    _require_global_analytics_access()
     filters = {
         "type": (request.args.get("type") or "").strip(),
         "stage": (request.args.get("stage") or "").strip(),
@@ -11004,7 +11015,7 @@ def admin_revenue():
 @admin_required
 @admin_role_required("superadmin")
 def admin_revenue_quick_action(item_type: str, item_id: int):
-    _require_global_admin()
+    _require_global_analytics_access()
     action = (request.form.get("action") or "").strip().lower()
     note = (request.form.get("note") or "").strip()
     now = _now_utc()
@@ -11058,7 +11069,11 @@ def admin_revenue_quick_action(item_type: str, item_id: int):
 
 
 @admin_bp.get("/api/high-intent-sessions")
+@login_required
+@admin_required
+@admin_role_required("superadmin")
 def admin_high_intent_sessions():
+    _require_global_analytics_access()
 
     from collections import defaultdict
     from datetime import datetime, timedelta
@@ -11246,7 +11261,7 @@ def admin_high_intent_sessions():
 @admin_role_required("superadmin")
 def admin_audience_map():
     admin_required_404()
-    _require_global_admin()
+    _require_global_analytics_access()
     return render_template(
         "admin/audience_map.html",
         audience=_build_audience_map_context(),

--- a/templates/layouts/admin_workspace.html
+++ b/templates/layouts/admin_workspace.html
@@ -29,6 +29,7 @@
     {% set is_leads_active = current_path.startswith('/admin/professional-leads') %}
     {% set admin_role = (current_user.role or '')|lower %}
     {% set can_access_professional_leads = admin_role in ['superadmin', 'super_admin', 'super-admin'] %}
+    {% set can_access_global_analytics = admin_role in ['superadmin', 'super_admin', 'super-admin'] %}
     {% set is_revenue_active = current_path.startswith('/admin/revenue') %}
     {% set is_conversion_active = current_path.startswith('/admin/conversion-dashboard') %}
 {% set is_reports_active = current_path.startswith('/admin/reports') %}
@@ -57,12 +58,16 @@
           {% if can_access_professional_leads %}
           <a class="hc-admin-shellnav__link {{ 'is-active' if is_leads_active else '' }}" href="{{ url_for('admin.admin_professional_leads') }}" {% if is_leads_active %}aria-current="page"{% endif %}>Leads</a>
           {% endif %}
+          {% if can_access_global_analytics %}
           <a class="hc-admin-shellnav__link {{ 'is-active' if is_revenue_active else '' }}" href="{{ url_for('admin.admin_revenue') }}" {% if is_revenue_active %}aria-current="page"{% endif %}>Revenue</a>
+          {% endif %}
           <a class="hc-admin-shellnav__link {{ 'is-active' if is_conversion_active else '' }}" href="/admin/conversion-dashboard" {% if is_conversion_active %}aria-current="page"{% endif %}>Conversion</a>
 <a class="hc-admin-shellnav__link {{ 'is-active' if is_reports_active else '' }}"
 href="{{ url_for('admin.admin_operations_report') }}"
 {% if is_reports_active %}aria-current="page"{% endif %}>Rapports</a>
+          {% if can_access_global_analytics %}
           <a class="hc-admin-shellnav__link {{ 'is-active' if is_audience_active else '' }}" href="{{ url_for('admin.admin_audience_map') }}" {% if is_audience_active %}aria-current="page"{% endif %}>Audience</a>
+          {% endif %}
           <a class="hc-admin-shellnav__link {{ 'is-active' if is_integrations_active else '' }}" href="{{ url_for('admin.admin_integrations') }}" {% if is_integrations_active %}aria-current="page"{% endif %}>Connecteurs</a>
           <a class="hc-admin-shellnav__link {{ 'is-active' if is_security_active else '' }}" href="{{ url_for('admin.admin_security') }}" {% if is_security_active %}aria-current="page"{% endif %}>Sécurité</a>
           <a class="hc-admin-shellnav__link {{ 'is-active' if is_platform_active else '' }}" href="{{ url_for('admin.admin_structures') }}" {% if is_platform_active %}aria-current="page"{% endif %}>Plateforme</a>

--- a/tests/test_admin_global_analytics_access.py
+++ b/tests/test_admin_global_analytics_access.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from backend.helpchain_backend.src.admin_actor import AdminActor
+from backend.helpchain_backend.src.admin_policies import can_view_global_analytics
+from backend.models import AdminUser, Structure, utc_now
+
+
+def _login_admin(client, app, admin_user: AdminUser) -> None:
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(admin_user.id)
+        sess["user_id"] = admin_user.id
+        sess["admin_id"] = admin_user.id
+        sess["admin_user_id"] = admin_user.id
+        sess["role"] = admin_user.role
+        sess["is_authenticated"] = True
+        sess["is_admin"] = True
+        sess["admin_logged_in"] = True
+        sess["mfa_required"] = True
+        sess[app.config.get("MFA_SESSION_KEY", "mfa_ok")] = True
+        sess["mfa_ok_until"] = (utc_now() + timedelta(minutes=30)).isoformat()
+        sess["admin_mfa_last_verified"] = 4102444800
+        sess["admin_mfa_user_id"] = admin_user.id
+
+
+def _make_structure(session, *, name: str, slug: str) -> Structure:
+    row = Structure(name=name, slug=slug)
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _make_admin(
+    session,
+    *,
+    username: str,
+    email: str,
+    role: str,
+    structure_id: int | None,
+) -> AdminUser:
+    row = AdminUser(
+        username=username,
+        email=email,
+        password_hash="x",
+        role=role,
+        structure_id=structure_id,
+        is_active=True,
+        mfa_enabled=True,
+        totp_secret="global-analytics-test-secret",
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def test_can_view_global_analytics_allows_founder_global_superadmin():
+    actor = AdminActor(
+        admin_id=1,
+        role="superadmin",
+        structure_id=None,
+        is_authenticated=True,
+        is_platform_global=True,
+        auth_source="session",
+        raw_admin=None,
+    )
+
+    assert can_view_global_analytics(actor) is True
+
+
+def test_can_view_global_analytics_denies_structure_scoped_admin():
+    actor = AdminActor(
+        admin_id=2,
+        role="admin",
+        structure_id=9,
+        is_authenticated=True,
+        is_platform_global=False,
+        auth_source="session",
+        raw_admin=None,
+    )
+
+    assert can_view_global_analytics(actor) is False
+
+
+def test_can_view_global_analytics_preserves_structure_attached_superadmin_access():
+    actor = AdminActor(
+        admin_id=3,
+        role="superadmin",
+        structure_id=11,
+        is_authenticated=True,
+        is_platform_global=False,
+        auth_source="session",
+        raw_admin=None,
+    )
+
+    assert can_view_global_analytics(actor) is True
+
+
+def test_global_superadmin_can_access_global_analytics_surfaces_and_nav(app, session):
+    structure = _make_structure(
+        session,
+        name="Global Analytics Alpha",
+        slug="global-analytics-alpha",
+    )
+    global_admin = _make_admin(
+        session,
+        username="global_analytics_superadmin",
+        email="global-analytics-superadmin@test.local",
+        role="superadmin",
+        structure_id=None,
+    )
+    session.commit()
+
+    client = app.test_client()
+    _login_admin(client, app, global_admin)
+
+    requests_page = client.get("/admin/requests")
+    requests_html = requests_page.get_data(as_text=True)
+    revenue = client.get("/admin/revenue")
+    audience = client.get("/admin/audience-map")
+    high_intent = client.get("/admin/api/high-intent-sessions")
+
+    assert structure.id is not None
+    assert requests_page.status_code == 200
+    assert 'href="/admin/revenue"' in requests_html
+    assert 'href="/admin/audience-map"' in requests_html
+    assert revenue.status_code == 200
+    assert "Revenue Control Center" in revenue.get_data(as_text=True)
+    assert audience.status_code == 200
+    assert "Radar des signaux" in audience.get_data(as_text=True)
+    assert high_intent.status_code == 200
+    assert high_intent.is_json is True
+    assert "sessions" in high_intent.get_json()
+
+
+def test_structure_admin_cannot_access_global_analytics_surfaces_and_nav_is_hidden(
+    app, session
+):
+    structure = _make_structure(
+        session,
+        name="Scoped Analytics Beta",
+        slug="scoped-analytics-beta",
+    )
+    structure_admin = _make_admin(
+        session,
+        username="scoped_analytics_admin",
+        email="scoped-analytics-admin@test.local",
+        role="admin",
+        structure_id=structure.id,
+    )
+    session.commit()
+
+    client = app.test_client()
+    _login_admin(client, app, structure_admin)
+
+    requests_page = client.get("/admin/requests")
+    requests_html = requests_page.get_data(as_text=True)
+    revenue = client.get("/admin/revenue", follow_redirects=False)
+    audience = client.get("/admin/audience-map", follow_redirects=False)
+    high_intent = client.get("/admin/api/high-intent-sessions", follow_redirects=False)
+
+    assert requests_page.status_code == 200
+    assert 'href="/admin/revenue"' not in requests_html
+    assert 'href="/admin/audience-map"' not in requests_html
+    assert revenue.status_code == 403
+    assert audience.status_code == 403
+    assert high_intent.status_code == 403


### PR DESCRIPTION
## Summary
- migrates revenue/audience/high-intent analytics guards to can_view_global_analytics
- keeps founder/global behavior unchanged
- aligns workspace navigation visibility with backend authorization

## Validation
- admin policy tests passed
- global analytics access tests passed
- revenue dashboard tests passed
- audience map tests passed
- encoding guard passed
- git diff --check passed
