### PR TITLE
Add authorization decision observability

### DIFF
--- a/backend/helpchain_backend/src/routes/api.py
+++ b/backend/helpchain_backend/src/routes/api.py
@@ -31,6 +31,7 @@ from ..models import (
     Structure,
     db,
 )
+from ..security_logging import log_security_event
 from .admin import admin_required, admin_required_404, admin_role_required, _is_global_admin
 from ..security.api_authz import require_api_auth, require_roles
 
@@ -62,6 +63,37 @@ def _session_admin_request_scope():
             raise PermissionError("tenant-scoped admin missing structure")
         query = query.filter(Request.structure_id == int(structure_id))
     return actor, query
+
+
+def _log_admin_authz_denied(
+    *,
+    actor,
+    action: str,
+    resource_type: str,
+    resource_id: int | None,
+    reason: str,
+) -> None:
+    try:
+        log_security_event(
+            "admin_authz_decision",
+            actor_type="admin" if getattr(actor, "is_authenticated", False) else "anonymous",
+            actor_id=getattr(actor, "admin_id", None),
+            route=request.path,
+            method=request.method,
+            meta={
+                "actor_id": getattr(actor, "admin_id", None),
+                "actor_role": getattr(actor, "role", None),
+                "structure_id": getattr(actor, "structure_id", None),
+                "action": action,
+                "resource_type": resource_type,
+                "resource_id": resource_id,
+                "decision": "denied",
+                "reason": reason,
+                "request_path": request.path,
+            },
+        )
+    except Exception:
+        current_app.logger.exception("admin_authz_denied_logging_failed")
 
 _RELAY_ALLOWED_FIELDS = {
     "external_source",
@@ -832,7 +864,16 @@ def change_status():
             raise PermissionError("tenant-scoped admin missing structure")
 
         req = Request.query.filter(Request.id == int(request_id)).first()
-        if not req or not can_mutate_request(actor, req):
+        if req and not can_mutate_request(actor, req):
+            _log_admin_authz_denied(
+                actor=actor,
+                action="request.change_status",
+                resource_type="Request",
+                resource_id=req.id,
+                reason="tenant_scope_mismatch",
+            )
+            return jsonify({"success": False, "message": "Request not found"}), 404
+        if not req:
             return jsonify({"success": False, "message": "Request not found"}), 404
 
         req.status = new_status
@@ -882,7 +923,16 @@ def delete_request():
             raise PermissionError("tenant-scoped admin missing structure")
 
         req = Request.query.filter(Request.id == int(request_id)).first()
-        if not req or not can_mutate_request(actor, req):
+        if req and not can_mutate_request(actor, req):
+            _log_admin_authz_denied(
+                actor=actor,
+                action="request.delete",
+                resource_type="Request",
+                resource_id=req.id,
+                reason="tenant_scope_mismatch",
+            )
+            return jsonify({"success": False, "message": "Request not found"}), 404
+        if not req:
             return jsonify({"success": False, "message": "Request not found"}), 404
 
         # Delete logs first

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -240,7 +240,7 @@ from datetime import UTC, datetime, timedelta
 
 from backend.helpchain_backend.src.jwt_utils import encode_access_token
 from backend.helpchain_backend.src.routes import api as api_routes
-from backend.models import AdminUser, Request, Structure, User, utc_now
+from backend.models import AdminUser, Request, SecurityEvent, Structure, User, utc_now
 
 
 def _login_admin(client, app, admin_user: AdminUser) -> None:
@@ -475,6 +475,26 @@ def test_legacy_admin_change_status_stays_tenant_scoped(app, session):
     assert req_a.status == "done"
     assert req_b.status == "pending"
 
+    denied_event = (
+        session.query(SecurityEvent)
+        .filter(SecurityEvent.event_type == "admin_authz_decision")
+        .order_by(SecurityEvent.id.desc())
+        .first()
+    )
+    assert denied_event is not None
+    assert denied_event.actor_id == admin_a.id
+    assert denied_event.route == "/api/admin/change_status"
+    assert denied_event.method == "POST"
+    assert denied_event.meta["actor_id"] == admin_a.id
+    assert denied_event.meta["actor_role"] == "admin"
+    assert denied_event.meta["structure_id"] == _structure_a.id
+    assert denied_event.meta["action"] == "request.change_status"
+    assert denied_event.meta["resource_type"] == "Request"
+    assert denied_event.meta["resource_id"] == req_b.id
+    assert denied_event.meta["decision"] == "denied"
+    assert denied_event.meta["reason"] == "tenant_scope_mismatch"
+    assert denied_event.meta["request_path"] == "/api/admin/change_status"
+
 
 def test_legacy_admin_delete_request_requires_admin_session(client):
     response = client.post(
@@ -506,3 +526,23 @@ def test_legacy_admin_delete_request_stays_tenant_scoped(app, session):
 
     assert session.get(Request, req_a.id) is None
     assert session.get(Request, req_b.id) is not None
+
+    denied_event = (
+        session.query(SecurityEvent)
+        .filter(SecurityEvent.event_type == "admin_authz_decision")
+        .order_by(SecurityEvent.id.desc())
+        .first()
+    )
+    assert denied_event is not None
+    assert denied_event.actor_id == admin_a.id
+    assert denied_event.route == "/api/admin/delete_request"
+    assert denied_event.method == "POST"
+    assert denied_event.meta["actor_id"] == admin_a.id
+    assert denied_event.meta["actor_role"] == "admin"
+    assert denied_event.meta["structure_id"] == _structure_a.id
+    assert denied_event.meta["action"] == "request.delete"
+    assert denied_event.meta["resource_type"] == "Request"
+    assert denied_event.meta["resource_id"] == req_b.id
+    assert denied_event.meta["decision"] == "denied"
+    assert denied_event.meta["reason"] == "tenant_scope_mismatch"
+    assert denied_event.meta["request_path"] == "/api/admin/delete_request"


### PR DESCRIPTION
## Summary
- adds lightweight authorization decision observability for sensitive API actions
- logs denied decisions without sensitive payload content
- preserves existing API behavior

## Validation
- tests/test_api.py passed
- encoding guard passed
- git diff --check passed
