### PR TITLE
analytics: add founder outreach tracking engine

### DIFF
--- a/backend/helpchain_backend/src/services/founder_outreach.py
+++ b/backend/helpchain_backend/src/services/founder_outreach.py
@@ -1,0 +1,65 @@
+﻿from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+OUTREACH_STAGES = {
+    "not_contacted",
+    "contacted",
+    "replied",
+    "meeting_scheduled",
+    "pilot_started",
+    "rejected",
+    "dormant",
+}
+
+
+def normalize_outreach_stage(value: str | None) -> str:
+    stage = (value or "").strip().lower().replace("-", "_").replace(" ", "_")
+    return stage if stage in OUTREACH_STAGES else "not_contacted"
+
+
+def recommend_next_outreach_action(row: dict[str, Any]) -> str:
+    stage = normalize_outreach_stage(row.get("outreach_stage"))
+    relationship_stage = str(row.get("relationship_stage") or "")
+    followup_priority = str(row.get("followup_priority") or "")
+    account_strength = str(row.get("account_strength") or "")
+
+    if stage == "not_contacted" and followup_priority == "high":
+        return "Send first structured founder outreach"
+
+    if stage == "contacted":
+        return "Schedule follow-up if no response"
+
+    if stage == "replied":
+        return "Propose a short qualification call"
+
+    if stage == "meeting_scheduled":
+        return "Prepare pilot framing notes"
+
+    if stage == "pilot_started":
+        return "Track pilot success criteria"
+
+    if stage == "rejected":
+        return "Archive or revisit later"
+
+    if stage == "dormant":
+        return "Re-engage only if new activity appears"
+
+    if relationship_stage in {"pilot_framing", "pilot_discussion"} or account_strength == "strong":
+        return "Prepare personalized institutional outreach"
+
+    return "Continue observing"
+
+
+def build_outreach_status(row: dict[str, Any]) -> dict[str, Any]:
+    stage = normalize_outreach_stage(row.get("outreach_stage"))
+    now = datetime.now(timezone.utc).isoformat()
+
+    return {
+        "outreach_stage": stage,
+        "outreach_label": stage.replace("_", " ").title(),
+        "recommended_outreach_action": recommend_next_outreach_action(row),
+        "generated_at": now,
+    }

--- a/tests/test_founder_outreach.py
+++ b/tests/test_founder_outreach.py
@@ -1,0 +1,47 @@
+﻿from backend.helpchain_backend.src.services.founder_outreach import (
+    build_outreach_status,
+    normalize_outreach_stage,
+    recommend_next_outreach_action,
+)
+
+
+def test_normalize_outreach_stage_accepts_known_values():
+    assert normalize_outreach_stage("meeting scheduled") == "meeting_scheduled"
+    assert normalize_outreach_stage("pilot-started") == "pilot_started"
+
+
+def test_normalize_outreach_stage_defaults_unknown():
+    assert normalize_outreach_stage("banana") == "not_contacted"
+
+
+def test_recommend_first_outreach_for_high_priority_not_contacted():
+    assert (
+        recommend_next_outreach_action(
+            {
+                "outreach_stage": "not_contacted",
+                "followup_priority": "high",
+            }
+        )
+        == "Send first structured founder outreach"
+    )
+
+
+def test_recommend_call_after_reply():
+    assert (
+        recommend_next_outreach_action({"outreach_stage": "replied"})
+        == "Propose a short qualification call"
+    )
+
+
+def test_build_outreach_status_returns_actionable_payload():
+    payload = build_outreach_status(
+        {
+            "outreach_stage": "contacted",
+            "relationship_stage": "pilot_framing",
+        }
+    )
+
+    assert payload["outreach_stage"] == "contacted"
+    assert payload["outreach_label"] == "Contacted"
+    assert payload["recommended_outreach_action"] == "Schedule follow-up if no response"
+    assert payload["generated_at"]


### PR DESCRIPTION
Adds a deterministic founder outreach tracking engine with outreach stages, next-action recommendations, and tests. No schema migration or UI redesign.