### PR TITLE
analytics: add daily founder queue engine

### DIFF
--- a/backend/helpchain_backend/src/services/daily_founder_queue.py
+++ b/backend/helpchain_backend/src/services/daily_founder_queue.py
@@ -1,0 +1,142 @@
+﻿from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+URGENCY_WEIGHTS = {
+    "high": 40,
+    "medium": 20,
+    "low": 5,
+}
+
+
+STAGE_WEIGHTS = {
+    "operational_validation": 45,
+    "pilot_discussion": 40,
+    "pilot_framing": 35,
+    "governance_review": 22,
+    "institutional_evaluation": 18,
+    "discovery": 5,
+    "dormant": 0,
+}
+
+
+ACCOUNT_WEIGHTS = {
+    "strong": 35,
+    "moderate": 18,
+    "weak": 5,
+}
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _lower(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def compute_daily_priority_score(row: dict[str, Any]) -> int:
+    score = 0
+
+    score += min(_int(row.get("intent_score") or row.get("score")), 120)
+
+    score += URGENCY_WEIGHTS.get(_lower(row.get("followup_priority")), 0)
+    score += STAGE_WEIGHTS.get(_lower(row.get("relationship_stage")), 0)
+    score += ACCOUNT_WEIGHTS.get(_lower(row.get("account_strength")), 0)
+
+    if _lower(row.get("outreach_stage")) == "not_contacted":
+        score += 20
+
+    if _lower(row.get("possible_friction")):
+        score += 12
+
+    if _lower(row.get("territorial_intensity")) in {"high", "strategic"}:
+        score += 20
+
+    if row.get("repeated_engagement_detected"):
+        score += 18
+
+    return score
+
+
+def explain_daily_priority(row: dict[str, Any]) -> list[str]:
+    reasons: list[str] = []
+
+    if _int(row.get("intent_score") or row.get("score")) >= 100:
+        reasons.append("high institutional intent")
+
+    if _lower(row.get("followup_priority")) == "high":
+        reasons.append("follow-up priority is high")
+
+    if _lower(row.get("account_strength")) == "strong":
+        reasons.append("strong institutional account")
+
+    if _lower(row.get("relationship_stage")) in {"pilot_framing", "pilot_discussion", "operational_validation"}:
+        reasons.append("advanced relationship stage")
+
+    if _lower(row.get("outreach_stage")) == "not_contacted":
+        reasons.append("no outreach recorded yet")
+
+    if _lower(row.get("possible_friction")):
+        reasons.append("possible friction needs handling")
+
+    if row.get("repeated_engagement_detected"):
+        reasons.append("repeated engagement observed")
+
+    return reasons[:5]
+
+
+def recommended_daily_action(row: dict[str, Any]) -> str:
+    if row.get("recommended_outreach_action"):
+        return str(row["recommended_outreach_action"])
+
+    if row.get("recommended_relationship_action"):
+        return str(row["recommended_relationship_action"])
+
+    if row.get("account_recommendation"):
+        return str(row["account_recommendation"])
+
+    if row.get("recommended_action"):
+        return str(row["recommended_action"])
+
+    return "Continue observing"
+
+
+def build_daily_founder_queue(rows: list[dict[str, Any]], *, limit: int = 5) -> list[dict[str, Any]]:
+    queue: list[dict[str, Any]] = []
+
+    for row in rows or []:
+        priority_score = compute_daily_priority_score(row)
+        item = {
+            **row,
+            "daily_priority_score": priority_score,
+            "daily_priority_reasons": explain_daily_priority(row),
+            "daily_recommended_action": recommended_daily_action(row),
+        }
+        queue.append(item)
+
+    queue.sort(
+        key=lambda item: (
+            item.get("daily_priority_score") or 0,
+            item.get("intent_score") or item.get("score") or 0,
+        ),
+        reverse=True,
+    )
+
+    return queue[:limit]
+
+
+def summarize_daily_founder_queue(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    queue = build_daily_founder_queue(rows, limit=10)
+
+    return {
+        "total_candidates": len(rows or []),
+        "top_count": len(queue),
+        "highest_score": queue[0]["daily_priority_score"] if queue else 0,
+        "top_action": queue[0]["daily_recommended_action"] if queue else "Continue observing",
+    }

--- a/tests/test_daily_founder_queue.py
+++ b/tests/test_daily_founder_queue.py
@@ -1,0 +1,78 @@
+﻿from backend.helpchain_backend.src.services.daily_founder_queue import (
+    build_daily_founder_queue,
+    compute_daily_priority_score,
+    explain_daily_priority,
+    summarize_daily_founder_queue,
+)
+
+
+def test_compute_daily_priority_score_rewards_high_intent_and_strong_account():
+    score = compute_daily_priority_score(
+        {
+            "intent_score": 120,
+            "followup_priority": "high",
+            "relationship_stage": "pilot_framing",
+            "account_strength": "strong",
+            "outreach_stage": "not_contacted",
+        }
+    )
+
+    assert score >= 200
+
+
+def test_explain_daily_priority_returns_human_reasons():
+    reasons = explain_daily_priority(
+        {
+            "intent_score": 120,
+            "followup_priority": "high",
+            "account_strength": "strong",
+            "relationship_stage": "pilot_framing",
+            "outreach_stage": "not_contacted",
+        }
+    )
+
+    assert "high institutional intent" in reasons
+    assert "strong institutional account" in reasons
+
+
+def test_build_daily_founder_queue_orders_by_priority():
+    queue = build_daily_founder_queue(
+        [
+            {"uid": "low", "intent_score": 10, "account_strength": "weak"},
+            {
+                "uid": "hot",
+                "intent_score": 150,
+                "followup_priority": "high",
+                "relationship_stage": "pilot_discussion",
+                "account_strength": "strong",
+                "outreach_stage": "not_contacted",
+            },
+        ]
+    )
+
+    assert queue[0]["uid"] == "hot"
+    assert queue[0]["daily_priority_score"] > queue[1]["daily_priority_score"]
+
+
+def test_build_daily_founder_queue_uses_existing_recommended_action():
+    queue = build_daily_founder_queue(
+        [
+            {
+                "uid": "x",
+                "intent_score": 100,
+                "recommended_outreach_action": "Send first structured founder outreach",
+            }
+        ]
+    )
+
+    assert queue[0]["daily_recommended_action"] == "Send first structured founder outreach"
+
+
+def test_summarize_daily_founder_queue_returns_summary():
+    summary = summarize_daily_founder_queue(
+        [{"uid": "a", "intent_score": 100, "followup_priority": "high"}]
+    )
+
+    assert summary["total_candidates"] == 1
+    assert summary["top_count"] == 1
+    assert summary["highest_score"] > 0


### PR DESCRIPTION
Adds a deterministic daily founder queue engine for prioritizing which institutional accounts to contact today, with urgency scoring, reasons, recommended action, and tests. No schema migration or UI redesign.