### PR TITLE
analytics: surface daily founder queue in revenue dashboard

### DIFF
--- a/backend/helpchain_backend/src/routes/admin.py
+++ b/backend/helpchain_backend/src/routes/admin.py
@@ -185,6 +185,11 @@ from ..services.founder_cockpit import (
     group_founder_signals_by_territory,
     summarize_founder_actions,
 )
+
+from ..services.daily_founder_queue import (
+    build_daily_founder_queue,
+    summarize_daily_founder_queue,
+)
 from ..services.territorial_intelligence import (
     detect_priority_territories,
     normalize_territory_name,
@@ -10967,8 +10972,15 @@ def _revenue_audience_metadata(audience_context: dict | None) -> dict[str, objec
 
 def _build_founder_cockpit_context(rows: list[SimpleNamespace]) -> dict[str, object]:
     queue = build_founder_priority_queue(rows)
+    daily_source_rows = [
+        dict(item.__dict__) if hasattr(item, "__dict__") else dict(item)
+        for item in rows
+    ]
+
     return {
         "queue": queue[:8],
+        "daily_queue": build_daily_founder_queue(daily_source_rows, limit=5),
+        "daily_summary": summarize_daily_founder_queue(daily_source_rows),
         "alerts": build_founder_alerts(rows),
         "territories": group_founder_signals_by_territory(rows)[:6],
         "summary": summarize_founder_actions(rows),

--- a/templates/admin/revenue_dashboard.html
+++ b/templates/admin/revenue_dashboard.html
@@ -61,6 +61,57 @@
     </div>
     <div class="hc-founder-cockpit__grid p-3">
       <div class="hc-founder-cockpit__panel">
+        <div class="hc-founder-cockpit__heading">À contacter aujourd’hui</div>
+
+        <div class="hc-founder-cockpit__list">
+          {% for item in founder_cockpit.daily_queue %}
+            <article class="hc-founder-cockpit__item">
+              <div class="d-flex justify-content-between gap-2">
+                <strong class="text-truncate">
+                  {{ item.organization or item.account_name or "Institutional account" }}
+                </strong>
+
+                <span class="badge text-bg-primary">
+                  {{ item.daily_priority_score }}
+                </span>
+              </div>
+
+              <div class="hc-muted small mt-1">
+                {{ item.relationship_stage|replace('_', ' ') }}
+                · {{ item.account_strength }}
+                · {{ item.outreach_label or item.outreach_stage }}
+              </div>
+
+              {% if item.daily_priority_reasons %}
+                <div class="hc-founder-cockpit__chips mt-2">
+                  {% for reason in item.daily_priority_reasons %}
+                    <span class="badge text-bg-light border">
+                      {{ reason }}
+                    </span>
+                  {% endfor %}
+                </div>
+              {% endif %}
+
+              <div class="small mt-2">
+                <strong>Action:</strong>
+                {{ item.daily_recommended_action }}
+              </div>
+            </article>
+          {% else %}
+            <div class="hc-empty-state">
+              <div class="hc-empty-state__title">
+                No operational founder queue yet
+              </div>
+
+              <div class="hc-empty-state__text">
+                Institutional opportunities will appear here automatically.
+              </div>
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+
+      <div class="hc-founder-cockpit__panel">
         <div class="hc-founder-cockpit__heading">Top opportunities</div>
         <div class="hc-founder-cockpit__list">
           {% for item in founder_cockpit.queue %}


### PR DESCRIPTION
Adds the daily founder queue to the revenue dashboard UI and exposes daily queue context from the founder cockpit. No schema migration.