### PR TITLE
i18n: wrap founder queue dashboard strings

### DIFF
--- a/templates/admin/revenue_dashboard.html
+++ b/templates/admin/revenue_dashboard.html
@@ -61,7 +61,7 @@
     </div>
     <div class="hc-founder-cockpit__grid p-3">
       <div class="hc-founder-cockpit__panel">
-        <div class="hc-founder-cockpit__heading">À contacter aujourd’hui</div>
+        <div class="hc-founder-cockpit__heading">{{ _('À contacter aujourd’hui') }}</div>
 
         <div class="hc-founder-cockpit__list">
           {% for item in founder_cockpit.daily_queue %}
@@ -93,18 +93,18 @@
               {% endif %}
 
               <div class="small mt-2">
-                <strong>Action:</strong>
+                <strong>{{ _('Action:') }}</strong>
                 {{ item.daily_recommended_action }}
               </div>
             </article>
           {% else %}
             <div class="hc-empty-state">
               <div class="hc-empty-state__title">
-                No operational founder queue yet
+                {{ _('No operational founder queue yet') }}
               </div>
 
               <div class="hc-empty-state__text">
-                Institutional opportunities will appear here automatically.
+                {{ _('Institutional opportunities will appear here automatically.') }}
               </div>
             </div>
           {% endfor %}

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -9197,3 +9197,5 @@ msgstr "Aucune file opérationnelle fondateur pour le moment"
 
 msgid "Ã€ contacter aujourdâ€™hui"
 msgstr "À contacter aujourd’hui"
+msgid "À contacter aujourd’hui"
+msgstr "À contacter aujourd’hui"

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -9186,3 +9186,14 @@ msgstr ""
 
 #~ msgid "Ouvrir"
 #~ msgstr "Ouvrir"
+msgid "Action:"
+msgstr "Action :"
+
+msgid "Institutional opportunities will appear here automatically."
+msgstr "Les opportunités institutionnelles apparaîtront ici automatiquement."
+
+msgid "No operational founder queue yet"
+msgstr "Aucune file opérationnelle fondateur pour le moment"
+
+msgid "Ã€ contacter aujourdâ€™hui"
+msgstr "À contacter aujourd’hui"


### PR DESCRIPTION
Wraps new founder queue dashboard strings with translation helpers to satisfy i18n CI guard.