### PR TITLE
Fix mobile landing page typography and overflow

### DIFF
--- a/static/css/pages/home-premium-conversion.css
+++ b/static/css/pages/home-premium-conversion.css
@@ -2230,3 +2230,93 @@ body.hc-page-home .hc-home-premium__security-ctaActions .btn:focus-visible {
     transform: none;
   }
 }
+
+@media (max-width: 767.98px) {
+  html {
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+  }
+
+  html body.hc-page-home .hc-home-premium__hero-copy {
+    display: grid !important;
+    grid-template-columns: minmax(0, 1fr) !important;
+    gap: 0.75rem !important;
+    max-width: 100% !important;
+    padding-top: 0 !important;
+  }
+
+  html body.hc-page-home .hc-home-premium__hero-copy h1,
+  html body.hc-page-home .hc-home-premium__hero h1 {
+    max-width: 100% !important;
+    font-size: clamp(1.72rem, 7.2vw, 2.2rem) !important;
+    line-height: 1.04 !important;
+    letter-spacing: -0.04em !important;
+    text-wrap: balance;
+  }
+
+  html body.hc-page-home .hc-home-premium__lead,
+  html body.hc-page-home .hc-home-premium__hero-copy > .hc-home-premium__lead,
+  html body.hc-page-home .hc-home-premium__hero-demo-note,
+  html body.hc-page-home .hc-home-premium__hero-supportMeta {
+    max-width: 100% !important;
+  }
+
+  html body.hc-page-home .hc-home-premium__hero-support,
+  html body.hc-page-home .hc-home-premium__hero-supportInline,
+  html body.hc-page-home .hc-home-premium__hero-actions {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+
+  html body.hc-page-home .hc-home-premium__hero-actions {
+    flex-wrap: wrap !important;
+    gap: 0.75rem !important;
+  }
+
+  html body.hc-page-home .hc-home-premium__hero-actions .btn,
+  html body.hc-page-home .hc-home-premium__hero-actions .hc-btn,
+  html body.hc-page-home .hc-home-premium__cta-buttons .btn,
+  html body.hc-page-home .hc-home-premium__cta-buttons .hc-btn,
+  html body.hc-page-home .hc-home-premium__security-ctaActions .btn,
+  html body.hc-page-home .hc-home-premium__security-ctaActions .hc-btn {
+    width: 100% !important;
+    min-height: 48px !important;
+    max-width: 100% !important;
+    box-sizing: border-box !important;
+  }
+
+  html body.hc-page-home .hc-home-premium__section-head h2,
+  html body.hc-page-home .hc-home-premium__product-copy h2,
+  html body.hc-page-home .hc-home-premium__cta-copy h2 {
+    max-width: 100% !important;
+    font-size: clamp(1.65rem, 6.8vw, 2.2rem) !important;
+    line-height: 1.08 !important;
+    text-wrap: balance;
+  }
+
+  html body.hc-page-home .hc-home-premium__workflow-note {
+    width: 100% !important;
+    max-width: 100% !important;
+    box-sizing: border-box !important;
+  }
+}
+
+@media (max-width: 430px) {
+  html body.hc-page-home .hc-home-premium__hero {
+    padding-inline: clamp(14px, 4vw, 20px) !important;
+  }
+
+  html body.hc-page-home .hc-home-premium__hero-grid,
+  html body.hc-page-home .hc-home-premium__section--product .hc-home-premium__product-row,
+  html body.hc-page-home .hc-home-premium__section--product .hc-home-premium__product-row--reverse,
+  html body.hc-page-home .hc-home-premium__section--product .hc-home-premium__product-row--security,
+  html body.hc-page-home .hc-home-premium__section--network .hc-home-premium__network-card,
+  html body.hc-page-home .hc-home-premium__section--cta .hc-home-premium__cta-card {
+    padding: clamp(16px, 4.8vw, 18px) !important;
+  }
+
+  html body.hc-page-home .hc-home-premium__hero-copy h1,
+  html body.hc-page-home .hc-home-premium__hero h1 {
+    font-size: clamp(1.58rem, 7vw, 1.95rem) !important;
+  }
+}


### PR DESCRIPTION
## Summary
- stabilize landing-page hero typography on narrow screens with responsive clamp sizing
- prevent mobile CTA and note blocks from exceeding viewport width
- preserve desktop layout while removing mobile overflow and clipping risks

## Validation
- pre-commit responsive guard: 11 passed
- real-browser mobile verification completed across iPhone, Galaxy, Z Flip, Pixel, and WebKit iPhone Safari
